### PR TITLE
feat: Add AI coding agent observability (v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Unlike loading the entire OpenTelemetry documentation into an AI's context (whic
 - 📈 **Scaling Strategies**: Load balancing with sticky sessions for tail sampling
 - 🎯 **Sampling Intelligence**: Head vs tail sampling with statistical trade-off analysis
 - 🔍 **Meta-Monitoring**: Self-observability patterns for collector health
+- 🤖 **AI Agent Observability**: Configuration guides for monitoring Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, and other AI coding agents via OpenTelemetry
 - ✅ **Test & Validation Framework**: TDD-based testing methodology to ensure skill effectiveness
 
 ## Skill Structure
@@ -70,6 +71,16 @@ opentelemetry-skill/
 │   └── monitoring.md         # Self-monitoring patterns
 └── opentelemetry-skill-LICENSE  # Apache 2.0
 ```
+
+## Architecture Patterns
+
+| Category | Pattern | Description |
+|----------|---------|-------------|
+| **Kubernetes** | **DaemonSet / Gateway / Sidecar** | Choose based on workload type and data volume |
+| **Serverless** | **FaaS Extension Layer** | Lambda, Azure Functions, GCP with non-blocking export |
+| **Sampling** | **Head / Tail Sampling** | Trade-off between cost and completeness |
+| **Security** | **mTLS + RBAC** | Secure cross-network telemetry pipelines |
+| **AI Agents** | **Agent Telemetry** | Monitor coding agents as first-class services in your observability stack |
 
 ## Usage Examples
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: opentelemetry-skill
-description: Use when working with OpenTelemetry - configuring collectors, designing pipelines, instrumenting applications, implementing sampling strategies, managing cardinality, securing telemetry data, troubleshooting observability issues, writing OTTL transformations, making production observability architecture decisions, or applying production playbooks and platform team patterns from real-world OpenTelemetry deployments
+description: Use when working with OpenTelemetry - configuring collectors, designing pipelines, instrumenting applications, implementing sampling strategies, managing cardinality, securing telemetry data, troubleshooting observability issues, writing OTTL transformations, making production observability architecture decisions, or setting up observability for AI coding agents (Claude Code, Codex, Gemini CLI, GitHub Copilot, and others)
 license: Apache-2.0
 metadata:
   author: o11y.dev
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # OpenTelemetry Skill: Expert Observability Engineering Assistant
@@ -183,6 +183,19 @@ Use these triggers to load detailed reference documentation only when needed. Th
 - Stickiness requirements for stateful connectors (spanmetrics, servicegraph)
 - Stability levels and cardinality warnings
 
+### Trigger: AI Coding Agent Observability
+**Keywords**: "Claude Code", "Codex", "Codex CLI", "Gemini CLI", "Copilot", "GitHub Copilot", "Qwen Code", "OpenCode", "Cursor", "Windsurf", "Aider", "AI agent", "coding agent", "vibe coding", "AI coding", "coding assistant", "AI IDE", "agent telemetry", "agent observability", "agent monitoring"
+
+**Action**: Load `references/ai-agents.md`
+
+**Contains**:
+- AI coding agent OTel support matrix (traces, metrics, logs per agent)
+- Per-agent quick-start configuration (env vars, settings files)
+- Unified OTel Collector config for multi-agent ingestion
+- Event/metric taxonomy and GenAI semantic convention mapping
+- Dashboard patterns and community resources
+- Privacy controls and cardinality management for agent telemetry
+
 ### Trigger: Playbooks & Production Patterns
 **Keywords**: "playbook", "production playbook", "blog", "2025 blog", "production deployment", "real world", "example deployment", "platform team", "Gateway API", "mTLS", "Lambda extension", "decouple processor", "receiver creator", "annotation-based discovery", "auto-instrumentation", "zero-code", "eBPF", "compile-time instrumentation", "span naming", "attribute naming", "metric naming", "complex attributes", "Logs API", "events", "sampling update", "TraceState", "declarative config", "health check exclusion", "OTTL", "transform processor", "RPC conventions", "unroll processor"
 
@@ -244,6 +257,10 @@ Actively prevent these common mistakes:
 ❌ Using deprecated protocols (Zipkin, Jaeger) for new deployments
 ❌ Creating custom attribute names instead of using semantic conventions
 ❌ Ignoring component stability levels in production
+❌ Including prompt.id or session.id as metric dimensions (unbounded cardinality)
+❌ Enabling captureContent/OTEL_LOG_USER_PROMPTS in shared/production environments without PII controls
+❌ Assuming all AI coding agents emit traces (Claude Code and Codex exec do not)
+❌ Using delta temporality with backends that expect cumulative (e.g., VictoriaMetrics silently drops)
 
 ## Version and Compatibility
 
@@ -252,11 +269,15 @@ Actively prevent these common mistakes:
 - **Kubernetes**: v1.24+ (for native sidecar support)
 - **Go SDK**: v1.24.0+
 - **Python SDK**: v1.40.0+
+- **Claude Code Telemetry**: Compatible with current release (metrics + logs/events)
+- **Gemini CLI Telemetry**: v0.34.0+ (traces + metrics + logs, GenAI SemConv)
+- **GitHub Copilot OTel**: VS Code Insiders / latest stable (traces + metrics + events, GenAI SemConv)
+- **Codex CLI Telemetry**: v0.105.0+ (traces + logs in interactive mode; exec/mcp-server gaps)
 
 ## Skill Metadata
 
 - **Skill Name**: opentelemetry-skill
-- **Version**: 1.0.0
+- **Version**: 1.2.0
 - **Author**: o11y.dev
 - **License**: Apache 2.0
 - **Last Updated**: 2026-03-10

--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -1,0 +1,508 @@
+# AI Coding Agent Observability
+
+A comprehensive guide to monitoring AI coding agents (Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, and others) via OpenTelemetry.
+
+---
+
+## Table of Contents
+
+1. [Overview & Compatibility Matrix](#1-overview--compatibility-matrix)
+2. [Per-Agent Quick-Start Configs](#2-per-agent-quick-start-configs)
+3. [Unified Collector Config for Multi-Agent Ingestion](#3-unified-collector-config-for-multi-agent-ingestion)
+4. [Event & Metric Taxonomy](#4-event--metric-taxonomy)
+5. [Dashboard Patterns](#5-dashboard-patterns)
+6. [Privacy & Cardinality Considerations](#6-privacy--cardinality-considerations)
+7. [Known Gaps & Workarounds](#7-known-gaps--workarounds)
+
+---
+
+## 1. Overview & Compatibility Matrix
+
+| Agent | Vendor | Traces | Metrics | Logs/Events | GenAI SemConv | Config Method | Config File / Env Vars | Protocol | Official Docs |
+|-------|--------|--------|---------|-------------|---------------|---------------|------------------------|----------|---------------|
+| **Claude Code** | Anthropic | ❌ | ✅ | ✅ | ❌ (custom `claude_code.*`) | Env vars or `~/.claude/settings.json` | `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_*` | OTLP gRPC/HTTP | [docs](https://code.claude.com/docs/en/monitoring-usage) |
+| **Gemini CLI** | Google | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | `.gemini/settings.json` or env vars | `GEMINI_TELEMETRY_*` | OTLP gRPC | [docs](https://geminicli.com/docs/cli/telemetry/) |
+| **GitHub Copilot VS Code** | Microsoft | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | VS Code `settings.json` or env var | `COPILOT_OTEL_ENABLED` | OTLP HTTP | [docs](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents) |
+| **GitHub Copilot CLI** | Microsoft | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | Same span model as VS Code | `COPILOT_OTEL_ENABLED` | OTLP HTTP | [docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference) |
+| **OpenAI Codex CLI** | OpenAI | ⚠️ interactive only | ⚠️ interactive only | ✅ | ❌ (custom event names) | `~/.codex/config.toml` `[otel]` section | `~/.codex/config.toml` | OTLP gRPC | [docs](https://developers.openai.com/codex/config-advanced) |
+| **Qwen Code** | Alibaba | 🔜 planned | 🔜 planned | 🔜 planned | 🔜 planned | `.qwen/settings.json` | `.qwen/settings.json` | OTLP | [docs](https://qwenlm.github.io/qwen-code-docs/en/developers/development/telemetry/) |
+| **OpenCode** | Anomaly | ❌ | ❌ | ❌ | ❌ | Community plugin only | n/a | n/a | [plugin](https://github.com/DEVtheOPS/opencode-plugin-otel) |
+| **Cursor** | Anysphere | ❌ | ❌ | ❌ | ❌ | Via MCP servers only | n/a | n/a | — |
+| **Windsurf** | Cognition | ❌ | ❌ | ❌ | ❌ | Agent skills for user code only | n/a | n/a | — |
+| **Amazon Q Developer** | AWS | ❌ | ❌ | ❌ | ❌ | CloudWatch/CloudTrail only | n/a | n/a | — |
+| **Aider** | open-source | ❌ | ❌ | ❌ | ❌ | External wrapper only | n/a | n/a | — |
+
+### Legend
+
+- ✅ Supported and shipped
+- ⚠️ Partial support (see Known Gaps)
+- 🔜 Planned but not yet shipped
+- ❌ Not supported
+
+---
+
+## 2. Per-Agent Quick-Start Configs
+
+### 2.1 Claude Code
+
+Claude Code emits **metrics** and **logs/events** only — no traces. Telemetry is opt-in.
+
+**Minimum config (env vars):**
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+**Persistent config (`~/.claude/settings.json`):**
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative"
+  }
+}
+```
+
+**Privacy controls:**
+
+| Env Var | Default | Effect |
+|---------|---------|--------|
+| `OTEL_LOG_USER_PROMPTS` | `false` | Includes raw user prompts in log events |
+| `OTEL_LOG_TOOL_DETAILS` | `false` | Includes tool call parameters in logs |
+| `OTEL_METRICS_INCLUDE_SESSION_ID` | `false` | Adds `session.id` as metric dimension (⚠️ high cardinality) |
+
+> ⚠️ **Temporality**: Claude Code emits cumulative metrics. Set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` to match. VictoriaMetrics and some Prometheus backends will silently drop delta-converted metrics from cumulative sources.
+
+---
+
+### 2.2 Gemini CLI
+
+Gemini CLI emits full **traces + metrics + logs** using GenAI semantic conventions (`gen_ai.*`).
+
+**Config file (`.gemini/settings.json`):**
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "otlpEndpoint": "http://localhost:4317",
+    "otlpProtocol": "grpc",
+    "logPrompts": false
+  }
+}
+```
+
+**Env var override:**
+
+```bash
+export GEMINI_TELEMETRY_ENABLED=true
+export GEMINI_TELEMETRY_OTLP_ENDPOINT=http://localhost:4317
+```
+
+> ✅ Gemini CLI v0.34.0+ follows `gen_ai.*` GenAI semantic conventions. Traces include full span hierarchy for multi-step agent operations.
+
+---
+
+### 2.3 GitHub Copilot (VS Code)
+
+**VS Code `settings.json`:**
+
+```json
+{
+  "github.copilot.chat.otel.enabled": true,
+  "github.copilot.chat.otel.otlpEndpoint": "http://localhost:4318",
+  "github.copilot.chat.otel.exporterType": "otlp-http",
+  "github.copilot.chat.otel.captureContent": false
+}
+```
+
+**Env var alternative:**
+
+```bash
+export COPILOT_OTEL_ENABLED=true
+export COPILOT_OTEL_OTLP_ENDPOINT=http://localhost:4318
+```
+
+> ⚠️ `captureContent: true` captures **full prompts and responses**. Keep this `false` in shared or production environments. See [Privacy section](#6-privacy--cardinality-considerations).
+
+---
+
+### 2.4 GitHub Copilot CLI
+
+Copilot CLI shares the same span model as the VS Code extension. Uses OTLP HTTP by default.
+
+```bash
+export COPILOT_OTEL_ENABLED=true
+export COPILOT_OTEL_OTLP_ENDPOINT=http://localhost:4318
+```
+
+---
+
+### 2.5 OpenAI Codex CLI
+
+Codex CLI supports telemetry in **interactive mode only**. `codex exec` and `codex mcp-server` have known gaps (see [Known Gaps](#7-known-gaps--workarounds)).
+
+**Config file (`~/.codex/config.toml`):**
+
+```toml
+[otel]
+exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+log_user_prompt = false
+```
+
+**Minimum config only:**
+
+```toml
+[otel]
+exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
+```
+
+> ⚠️ Codex v0.105.0+ is required. `codex exec` drops metrics entirely. `codex mcp-server` has zero OTel support. See [open issue #12913](https://github.com/openai/codex/issues/12913).
+
+---
+
+### 2.6 Qwen Code (Watch — Not Yet Shipped)
+
+Docs describe a telemetry system with `.qwen/settings.json`, but the corresponding code has not shipped as of 2026-03. Monitor the [Qwen Code telemetry docs](https://qwenlm.github.io/qwen-code-docs/en/developers/development/telemetry/) for updates.
+
+**Planned config (`.qwen/settings.json`):**
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "otlpEndpoint": "http://localhost:4317"
+  }
+}
+```
+
+---
+
+### 2.7 Agents Without Native OTel
+
+| Agent | Workaround |
+|-------|-----------|
+| **OpenCode** | Community plugin: [opencode-plugin-otel](https://github.com/DEVtheOPS/opencode-plugin-otel). Feature request: [#14697](https://github.com/anomalyco/opencode/issues/14697) |
+| **Cursor** | Use MCP servers (Traceloop, Observe) to instrument the user's code, not Cursor itself |
+| **Windsurf** | Agent skills can add OTel to user code; Windsurf itself emits nothing |
+| **Amazon Q Developer** | Use CloudWatch and CloudTrail for activity logging; no OTLP export |
+| **Aider** | Wrap with a shell script that records start/stop times and token usage from stdout |
+
+---
+
+## 3. Unified Collector Config for Multi-Agent Ingestion
+
+A single OTel Collector instance can receive telemetry from all agents simultaneously on standard OTLP ports.
+
+```yaml
+# otel-collector-ai-agents.yaml
+# Production-ready config for multi-agent AI coding observability
+# Tested with OTel Collector v0.147.0+
+
+extensions:
+  health_check:
+    endpoint: localhost:13133
+  file_storage:
+    directory: /var/lib/otelcol/filestore
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317   # Claude Code, Gemini CLI, Codex CLI (grpc)
+      http:
+        endpoint: 0.0.0.0:4318   # GitHub Copilot VS Code/CLI (http)
+
+processors:
+  # CRITICAL: memory_limiter MUST be first processor in every pipeline
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  # Normalize service.name across all agents
+  resource:
+    attributes:
+      - key: service.name
+        action: upsert
+        from_attribute: service.name
+      # Tag all AI agent telemetry for easy filtering
+      - key: telemetry.source.type
+        value: ai-coding-agent
+        action: insert
+
+  # Map custom claude_code.* prefixes to gen_ai.* where semantically equivalent
+  transform/normalize_agent_metrics:
+    metric_statements:
+      - context: datapoint
+        statements:
+          # Claude Code uses claude_code.* prefix — surface agent name for dashboards
+          - set(attributes["gen_ai.system"], "claude_code") where resource.attributes["service.name"] == "claude_code"
+          - set(attributes["gen_ai.system"], "gemini_cli") where resource.attributes["service.name"] == "gemini_cli"
+    log_statements:
+      - context: log
+        statements:
+          # Normalize agent identifier in log body for cross-agent queries
+          - set(attributes["gen_ai.system"], "claude_code") where resource.attributes["service.name"] == "claude_code"
+
+  # Redact secrets from tool_parameters (reuse security.md pattern)
+  transform/redact_secrets:
+    log_statements:
+      - context: log
+        statements:
+          - replace_pattern(attributes["tool.parameters"], "(?i)(api[_-]?key|secret|token|password)[\"'\\s]*[:=][\"'\\s]*[^\\s,}]+", "REDACTED")
+
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  # Metrics → Prometheus (scraped by Grafana)
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: ai_agent
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  # Logs → Loki
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+    sending_queue:
+      enabled: true
+      storage: file_storage
+    retry_on_failure:
+      enabled: true
+
+  # Traces → Tempo (for agents that emit traces: Gemini CLI, Copilot)
+  otlp/tempo:
+    endpoint: http://tempo:4317
+    sending_queue:
+      enabled: true
+      storage: file_storage
+    retry_on_failure:
+      enabled: true
+
+service:
+  extensions: [health_check, file_storage]
+  pipelines:
+    # Metrics pipeline — all agents
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, transform/normalize_agent_metrics, batch]
+      exporters: [prometheus]
+
+    # Logs/Events pipeline — all agents
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, transform/normalize_agent_metrics, transform/redact_secrets, batch]
+      exporters: [otlphttp/loki]
+
+    # Traces pipeline — Gemini CLI, Copilot only (others emit nothing here)
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [otlp/tempo]
+```
+
+> **Processor ordering**: `memory_limiter` is always first. The `resource` processor runs before `transform` so enriched attributes are available for OTTL statements. `batch` is always last before exporters.
+
+---
+
+## 4. Event & Metric Taxonomy
+
+### 4.1 Metrics
+
+| Agent | Metric Name | Type | Unit | Key Attributes |
+|-------|-------------|------|------|----------------|
+| Claude Code | `claude_code.tokens.input` | Counter | `{token}` | `model`, `session.id` |
+| Claude Code | `claude_code.tokens.output` | Counter | `{token}` | `model`, `session.id` |
+| Claude Code | `claude_code.cost.usd` | Counter | `USD` | `model` |
+| Claude Code | `claude_code.api.request.duration` | Histogram | `ms` | `model`, `status` |
+| Claude Code | `claude_code.tool.call.count` | Counter | `{call}` | `tool.name`, `status` |
+| Claude Code | `claude_code.cache.read.tokens` | Counter | `{token}` | `model` |
+| Gemini CLI | `gen_ai.client.token.usage` | Counter | `{token}` | `gen_ai.system`, `gen_ai.token.type`, `gen_ai.operation.name` |
+| Gemini CLI | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.response.finish_reason` |
+| GitHub Copilot | `gen_ai.client.token.usage` | Counter | `{token}` | `gen_ai.system`, `gen_ai.token.type` |
+| GitHub Copilot | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.system`, `gen_ai.operation.name` |
+| Codex CLI | `codex.tokens.used` | Counter | `{token}` | `model`, `direction` |
+| Codex CLI | `codex.request.latency` | Histogram | `ms` | `model`, `status` |
+
+### 4.2 Events / Logs
+
+| Agent | Event Name | Key Attributes | Correlation ID Field |
+|-------|------------|----------------|---------------------|
+| Claude Code | `gen_ai.user.message` | `gen_ai.system`, `session.id`, `prompt.id` | `prompt.id` |
+| Claude Code | `gen_ai.assistant.message` | `gen_ai.system`, `session.id`, `prompt.id`, `model` | `prompt.id` |
+| Claude Code | `gen_ai.tool.message` | `tool.name`, `session.id`, `prompt.id` | `prompt.id` |
+| Claude Code | `claude_code.api.request` | `model`, `prompt.id`, `input_tokens`, `output_tokens`, `cost_usd` | `prompt.id` |
+| Gemini CLI | `gen_ai.user.message` | `gen_ai.system`, `gen_ai.conversation.id` | `gen_ai.conversation.id` |
+| Gemini CLI | `gen_ai.assistant.message` | `gen_ai.system`, `gen_ai.conversation.id`, `gen_ai.response.model` | `gen_ai.conversation.id` |
+| GitHub Copilot | `gen_ai.user.message` | `gen_ai.system`, `gen_ai.thread.id` | `gen_ai.thread.id` |
+| GitHub Copilot | `gen_ai.choice` | `gen_ai.system`, `gen_ai.response.finish_reason` | `gen_ai.thread.id` |
+| Codex CLI | `codex.session.start` | `session.id`, `model`, `working_dir` | `session.id` |
+| Codex CLI | `codex.session.end` | `session.id`, `total_tokens`, `total_cost_usd` | `session.id` |
+
+### 4.3 Traces (where supported)
+
+| Agent | Span Name | Kind | Key Attributes | Child Spans |
+|-------|-----------|------|----------------|-------------|
+| Gemini CLI | `gen_ai.chat` | `CLIENT` | `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.request.model` | tool call spans |
+| Gemini CLI | `execute_tool` | `INTERNAL` | `gen_ai.tool.name`, `gen_ai.tool.call.id` | none |
+| GitHub Copilot | `gen_ai.chat` | `CLIENT` | `gen_ai.system`, `gen_ai.operation.name` | completion spans |
+| GitHub Copilot | `gen_ai.completion` | `INTERNAL` | `gen_ai.response.finish_reason`, `gen_ai.usage.input_tokens` | none |
+
+> **Note**: Claude Code emits **no traces**. Use `prompt.id` correlation across log events as a pseudo-trace (see [Known Gaps](#7-known-gaps--workarounds)).
+
+---
+
+## 5. Dashboard Patterns
+
+### 5.1 Community Dashboards
+
+| Dashboard | Agents Covered | Stack | Link |
+|-----------|---------------|-------|------|
+| **ai-observer** | Claude Code + Gemini CLI + Codex CLI | Any OTLP backend | [github.com/tobilg/ai-observer](https://github.com/tobilg/ai-observer) |
+| **claude-code-otel** | Claude Code | Grafana + Prometheus | [github.com/ColeMurray/claude-code-otel](https://github.com/ColeMurray/claude-code-otel) |
+| **Honeycomb Claude Code template** | Claude Code | Honeycomb | Built-in board template (search "Claude Code" in Honeycomb) |
+| **Gemini CLI GCP Monitoring** | Gemini CLI | GCP Monitoring | Pre-configured template in GCP Console |
+
+### 5.2 Recommended Dashboard Panels
+
+Build these panels for a team-facing AI agent observability dashboard:
+
+1. **Token usage by agent/user/model over time**
+   - Metric: `claude_code.tokens.input` + `claude_code.tokens.output` (Claude Code); `gen_ai.client.token.usage` (Gemini, Copilot)
+   - Dimensions: `model`, `gen_ai.system` (NOT `session.id` — high cardinality)
+   - Chart type: Stacked bar, 1h buckets
+
+2. **Cost breakdown by agent and model**
+   - Metric: `claude_code.cost.usd` (Claude Code); derived from token counts × model pricing for others
+   - Dimensions: `gen_ai.system`, `model`
+   - Chart type: Time series + running total stat panel
+
+3. **API request latency (p50/p95/p99)**
+   - Metric: `claude_code.api.request.duration` (Claude Code); `gen_ai.client.operation.duration` (GenAI SemConv agents)
+   - Chart type: Heatmap or percentile time series
+
+4. **Tool call success/failure rates**
+   - Metric: `claude_code.tool.call.count` with `status` dimension
+   - Log query: filter `gen_ai.tool.message` events by `status`
+   - Chart type: Success rate gauge + error rate alert
+
+5. **Active sessions / DAU/WAU/MAU**
+   - Source: Log events with `session.id` (count distinct via log query, not metric dimension)
+   - Chart type: Unique session count per day/week/month
+
+6. **Cache hit ratio (Claude Code)**
+   - Metric: `claude_code.cache.read.tokens` / (`claude_code.tokens.input` + `claude_code.cache.read.tokens`)
+   - Chart type: Single stat percentage gauge
+
+---
+
+## 6. Privacy & Cardinality Considerations
+
+### 6.1 High-Cardinality Fields
+
+| Field | Cardinality | Recommendation |
+|-------|------------|----------------|
+| `prompt.id` | Unbounded | Use in **logs/events only**, never as metric dimension |
+| `session.id` | Unbounded | Use in **logs/events only**; keep `OTEL_METRICS_INCLUDE_SESSION_ID=false` |
+| `user.id` | Bounded by team size | Acceptable as metric dimension for small teams (<1000 users); use logs for larger orgs |
+| `model` | Low (~5–20 values) | Safe as metric dimension |
+| `gen_ai.system` | Low (~10 values) | Safe as metric dimension |
+| `tool.name` | Low–Medium | Acceptable as metric dimension if tools are bounded |
+
+> **Rule of 100**: Any attribute with >100 unique values should NOT be a metric dimension. Use logs or traces instead.
+
+### 6.2 Prompt Content Controls
+
+| Agent | Default | Opt-in for Content |
+|-------|---------|-------------------|
+| Claude Code | Prompts **redacted** | `OTEL_LOG_USER_PROMPTS=true` |
+| Codex CLI | Prompts **redacted** | `log_user_prompt = true` in config.toml |
+| GitHub Copilot | Content **not captured** | `captureContent: true` in settings |
+| Gemini CLI | Prompts **not logged** | `logPrompts: true` in settings.json |
+
+> ⚠️ **Production Warning**: Never enable prompt capture in shared or production environments without explicit PII controls. User prompts frequently contain secrets, credentials, and personal data.
+
+### 6.3 OTTL Redaction Patterns
+
+Add to your collector config to redact secrets from tool parameters before they reach backends:
+
+```yaml
+transform/redact_agent_secrets:
+  log_statements:
+    - context: log
+      statements:
+        # Redact API keys and tokens from tool parameters
+        - replace_pattern(attributes["tool.parameters"], "(?i)(api[_-]?key|secret|token|password|bearer)[\"'\\s]*[:=][\"'\\s]*[^\\s,}\"']+", "${1}=REDACTED")
+        # Redact AWS credentials
+        - replace_pattern(attributes["tool.parameters"], "AKIA[0-9A-Z]{16}", "REDACTED_AWS_KEY")
+        # Redact connection strings
+        - replace_pattern(attributes["tool.parameters"], "(postgresql|mysql|mongodb)://[^@]+@", "${1}://REDACTED@")
+```
+
+See `references/security.md` for comprehensive OTTL redaction patterns.
+
+---
+
+## 7. Known Gaps & Workarounds
+
+### 7.1 Claude Code: No Traces
+
+**Gap**: Claude Code emits metrics and logs/events, but **no distributed traces**. There is no W3C `traceparent` propagation.
+
+**Workaround — Pseudo-trace via `prompt.id` correlation**:
+
+```
+prompt.id = "prompt_abc123"
+
+Log events sharing this prompt.id form a "trace":
+  → gen_ai.user.message   (prompt.id=prompt_abc123)
+  → claude_code.api.request (prompt.id=prompt_abc123)
+  → gen_ai.tool.message   (prompt.id=prompt_abc123, tool.name=bash)
+  → gen_ai.assistant.message (prompt.id=prompt_abc123)
+```
+
+Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123"` to reconstruct a session's event timeline.
+
+### 7.2 Codex CLI: Exec and MCP-Server Gaps
+
+**Gap**: `codex exec` (non-interactive batch mode) drops **all metrics**. `codex mcp-server` has **zero OTel instrumentation**.
+
+**Status**: Open issue — [github.com/openai/codex/issues/12913](https://github.com/openai/codex/issues/12913)
+
+**Workaround**: Use interactive `codex` mode for telemetry. For `codex exec` pipelines, instrument the calling shell script with timing/exit code metrics via a Prometheus Pushgateway or write structured JSON logs that a filelog receiver can ingest.
+
+### 7.3 Qwen Code: Docs Without Code
+
+**Gap**: Alibaba has published telemetry documentation but the implementation code has not shipped as of 2026-03.
+
+**Action**: Watch the [Qwen Code changelog](https://qwenlm.github.io/qwen-code-docs/en/developers/development/telemetry/) and the repo for the enabling commit. Do not build infrastructure dependencies on Qwen Code telemetry until code ships.
+
+### 7.4 Cross-Agent Trace Correlation
+
+**Gap**: No W3C `traceparent` propagation exists between AI coding agents. If Claude Code calls a tool that triggers Gemini CLI (or vice versa via MCP), there is no automatic trace linkage.
+
+**Workaround**: Use a shared `session.id` or custom correlation attribute passed as metadata to link events across agents in log queries. True distributed tracing across agents is not possible today.
+
+### 7.5 GenAI SemConv Coverage
+
+| Agent | Uses `gen_ai.*` | Custom Prefix | Notes |
+|-------|----------------|---------------|-------|
+| Gemini CLI | ✅ Full | — | Follows `gen_ai.*` v1.40.0+ |
+| GitHub Copilot | ✅ Full | — | Follows `gen_ai.*` v1.40.0+ |
+| Claude Code | ❌ | `claude_code.*` | Uses OTTL `transform` to map (see §3) |
+| Codex CLI | ❌ | `codex.*` | Custom event names, partial coverage |
+| Qwen Code | 🔜 planned | `.qwen.*` | Not yet verifiable |
+
+Use the `transform/normalize_agent_metrics` processor from [§3](#3-unified-collector-config-for-multi-agent-ingestion) to add `gen_ai.system` attributes to Claude Code and Codex telemetry for unified dashboard queries.

--- a/tests/ai-agent-scenarios.md
+++ b/tests/ai-agent-scenarios.md
@@ -1,0 +1,195 @@
+# AI Agent Observability Test Scenarios
+
+**Phase**: RED → GREEN (TDD)
+**Purpose**: Validate that the `references/ai-agents.md` reference causes the skill to materially improve responses to AI coding agent observability questions.
+
+---
+
+## How to Use These Scenarios
+
+1. **RED phase**: Test WITHOUT loading `references/ai-agents.md`. Record baseline responses.
+2. **GREEN phase**: Test WITH skill active (SKILL.md loaded + ai-agents.md trigger fires). Verify improvements.
+3. **REFACTOR**: Document any agent rationalizations and add counter-guidance.
+
+---
+
+## Scenario 1: Claude Code Telemetry Setup
+
+**Prompt**:
+> "Set up OpenTelemetry monitoring for Claude Code to track token usage and costs"
+
+### Expected WITHOUT skill (RED baseline)
+
+- May not know `CLAUDE_CODE_ENABLE_TELEMETRY=1` is required (telemetry is opt-in)
+- Likely suggests wrong or generic env var names
+- Will not mention `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`
+- No mention of `~/.claude/settings.json` for persistent config
+- No privacy controls (`OTEL_LOG_USER_PROMPTS`, `OTEL_LOG_TOOL_DETAILS`)
+- No cardinality warning about `session.id` as metric dimension
+- Generic collector YAML without Claude Code-specific considerations
+
+### Expected WITH skill (GREEN target)
+
+- ✅ Includes `CLAUDE_CODE_ENABLE_TELEMETRY=1` as prerequisite
+- ✅ Provides exact env vars: `OTEL_METRICS_EXPORTER=otlp`, `OTEL_LOGS_EXPORTER=otlp`
+- ✅ Shows `~/.claude/settings.json` persistent config format
+- ✅ Sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`
+- ✅ Warns about `OTEL_METRICS_INCLUDE_SESSION_ID` and cardinality risk
+- ✅ Mentions privacy controls are off by default
+- ✅ Notes Claude Code emits metrics + logs, NOT traces
+
+### Compliance Check
+
+- [ ] Response includes `CLAUDE_CODE_ENABLE_TELEMETRY=1`
+- [ ] Response includes `settings.json` persistent config example
+- [ ] Response mentions cumulative temporality preference
+- [ ] Response warns about session.id as metric dimension
+- [ ] Response notes no traces are emitted
+
+---
+
+## Scenario 2: Multi-Agent Collector
+
+**Prompt**:
+> "I use Claude Code and Gemini CLI. Configure a single OTel Collector to receive telemetry from both."
+
+### Expected WITHOUT skill (RED baseline)
+
+- Likely generates two separate, disconnected configs
+- No normalization of `service.name` across agents
+- May not know Claude Code uses gRPC (4317) while Copilot uses HTTP (4318)
+- No resource processor to unify agent identifiers
+- No OTTL transform to map `claude_code.*` to `gen_ai.*`
+- `memory_limiter` may be missing or in wrong position
+
+### Expected WITH skill (GREEN target)
+
+- ✅ Single OTLP receiver with both gRPC (4317) and HTTP (4318) protocols enabled
+- ✅ `memory_limiter` as first processor in every pipeline
+- ✅ `resource` processor to tag `telemetry.source.type: ai-coding-agent`
+- ✅ `transform` processor adding `gen_ai.system` attribute to Claude Code data
+- ✅ Separate pipelines for metrics, logs, traces
+- ✅ Notes Claude Code emits no traces (traces pipeline still useful for Gemini CLI)
+- ✅ `batch` processor last before exporters
+
+### Compliance Check
+
+- [ ] Single config with both gRPC and HTTP listeners
+- [ ] `memory_limiter` is first processor
+- [ ] `resource` processor normalizes agent identity
+- [ ] Separate metrics/logs/traces pipelines
+- [ ] Notes Claude Code has no traces
+
+---
+
+## Scenario 3: Agent OTel Support Comparison
+
+**Prompt**:
+> "Which AI coding agents support OpenTelemetry? I need traces specifically for debugging multi-step agent operations."
+
+### Expected WITHOUT skill (RED baseline)
+
+- Vague or outdated answer based on training data
+- May incorrectly claim Claude Code supports traces
+- Likely misses Codex CLI partial support gaps
+- No mention of Qwen Code "planned but not shipped" status
+- No mention of OpenCode/Cursor/Windsurf having no native OTel
+- No guidance on GenAI SemConv coverage
+
+### Expected WITH skill (GREEN target)
+
+- ✅ Gemini CLI: full traces ✅, follows `gen_ai.*` SemConv, v0.34.0+
+- ✅ GitHub Copilot (VS Code + CLI): full traces ✅, follows `gen_ai.*` SemConv
+- ✅ Claude Code: NO traces ❌ — metrics + logs only; use `prompt.id` as pseudo-trace correlation
+- ✅ Codex CLI: traces ⚠️ in interactive mode only; `codex exec` drops metrics
+- ✅ Qwen Code: planned but not shipped 🔜
+- ✅ OpenCode, Cursor, Windsurf, Aider: no native OTel ❌
+- ✅ Recommends Gemini CLI or Copilot if traces are a hard requirement
+
+### Compliance Check
+
+- [ ] Correctly identifies Gemini CLI and Copilot as trace-capable
+- [ ] Correctly states Claude Code has NO traces
+- [ ] Mentions Codex CLI partial support limitation
+- [ ] Notes Qwen Code is planned but not shipped
+- [ ] Suggests GenAI SemConv coverage as selection criterion
+
+---
+
+## Scenario 4: Privacy Controls for Claude Code
+
+**Prompt**:
+> "Enable Claude Code telemetry but make sure no user prompts are logged"
+
+### Expected WITHOUT skill (RED baseline)
+
+- May accidentally enable `OTEL_LOG_USER_PROMPTS=true` without warning
+- Likely omits privacy env vars entirely
+- No mention that prompts are redacted by default
+- No warning about `OTEL_LOG_TOOL_DETAILS` leaking tool parameters
+- No OTTL redaction recommendation for tool parameters that may contain secrets
+
+### Expected WITH skill (GREEN target)
+
+- ✅ States prompts are redacted by default — `OTEL_LOG_USER_PROMPTS` defaults to `false`
+- ✅ Explicitly sets `OTEL_LOG_USER_PROMPTS=false` (or omits it, noting the safe default)
+- ✅ Warns about `OTEL_LOG_TOOL_DETAILS` — tool parameters may contain secrets/paths
+- ✅ Recommends OTTL redaction processor for tool_parameters as defense-in-depth
+- ✅ Notes `captureContent` risk if user later adopts GitHub Copilot
+- ✅ Warns about `OTEL_METRICS_INCLUDE_SESSION_ID=false` (cardinality, not PII, but related)
+
+### Compliance Check
+
+- [ ] States prompts are redacted by default in Claude Code
+- [ ] Addresses `OTEL_LOG_TOOL_DETAILS` specifically
+- [ ] Includes or recommends OTTL redaction for tool parameters
+- [ ] Does NOT accidentally suggest enabling prompt logging
+
+---
+
+## Scenario 5: Dashboard Recommendations for Team AI Usage
+
+**Prompt**:
+> "What dashboards should I build for monitoring our team's AI coding agent usage?"
+
+### Expected WITHOUT skill (RED baseline)
+
+- Generic "build a dashboard" advice
+- Vague panel suggestions without specific metric names
+- No mention of community-built dashboards
+- May suggest using `user.id` or `session.id` as metric dimensions (cardinality risk)
+- No cost breakdown guidance
+- No distinction between metrics-based and log-based panels
+
+### Expected WITH skill (GREEN target)
+
+- ✅ References community dashboards: ai-observer, ColeMurray/claude-code-otel, Honeycomb template
+- ✅ Panel 1: Token usage by model/agent over time — NOT by session.id
+- ✅ Panel 2: Cost breakdown by agent and model
+- ✅ Panel 3: API latency percentiles (p50/p95/p99)
+- ✅ Panel 4: Tool call success/failure rates
+- ✅ Panel 5: Active sessions via log queries (not metric dimensions)
+- ✅ Panel 6: Cache hit ratio for Claude Code
+- ✅ Warns about session.id/prompt.id cardinality if put in metric dimensions
+- ✅ Notes some agents (Claude Code) require log-based queries for session counts
+
+### Compliance Check
+
+- [ ] References at least one community dashboard (ai-observer or ColeMurray)
+- [ ] Lists token usage, cost, and latency panels with specific metric names
+- [ ] Warns about session.id as metric dimension
+- [ ] Suggests log-based queries for session/user counts
+- [ ] Mentions cache hit ratio for Claude Code
+
+---
+
+## Anti-Rationalization Notes
+
+Document observed agent rationalizations and counter-guidance here as they are discovered during testing.
+
+| Rationalization | Counter |
+|----------------|---------|
+| "Claude Code supports traces via the OTEL_TRACES_EXPORTER env var" | Claude Code explicitly does NOT emit traces. `OTEL_TRACES_EXPORTER` is ignored. Only metrics and logs are emitted. |
+| "You can use session.id as a metric label to track per-user costs" | session.id is unbounded cardinality. Use log queries with distinct count instead. |
+| "Qwen Code telemetry is available now" | As of 2026-03, docs exist but code is not shipped. Verify before building on it. |
+| "Codex CLI telemetry works the same in exec mode" | `codex exec` drops ALL metrics. Interactive mode only for full telemetry. |


### PR DESCRIPTION
- Add references/ai-agents.md: compatibility matrix for 11 agents (Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, Qwen Code, OpenCode, Cursor, Windsurf, Amazon Q, Aider), per-agent quick-start configs, unified multi-agent collector config, event/metric taxonomy, dashboard patterns, privacy controls, and known gaps/workarounds
- Add tests/ai-agent-scenarios.md: 5 TDD scenarios covering setup, multi-agent collector, agent comparison, privacy, and dashboards
- Update SKILL.md: add AI agent trigger block, update description, add 4 anti-patterns, add agent version compatibility entries, bump version 1.1.0 → 1.2.0
- Update README.md: add AI Agent Observability feature bullet, add Architecture Patterns table with AI Agents row

https://claude.ai/code/session_018AxyMPPXs4fNcr5eNGPFzZ