### PR TITLE
feat: recommend opentelemetry-hooks for unsupported agents

### DIFF
--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -189,7 +189,9 @@ Docs describe a telemetry system with `.qwen/settings.json`, but the correspondi
 
 ### 2.7 Agents Without Native OTel
 
-For agents that emit no OpenTelemetry data, use **[opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks)** — a hook-based instrumentation layer that wraps any CLI tool and emits OTLP spans, metrics, and logs without modifying the agent itself.
+For agents that emit no OpenTelemetry data, use **[opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks)** — a hook-based instrumentation layer that wraps a process invocation (typically a CLI entrypoint) and emits OTLP spans, metrics, and logs without modifying the agent binary.
+
+> **Scope:** opentelemetry-hooks instruments the *wrapped process invocation*. For fully CLI-based agents (OpenCode, Aider, Amazon Q Developer CLI) this captures each agent run end-to-end. For GUI-first editors (Cursor, Windsurf) wrapping the launch command provides limited value because the main agent activity occurs inside the desktop process after startup; only the launch duration and exit code are reliably captured. Use the hooks approach for Cursor/Windsurf only if you have a headless/CLI agent invocation (for example `cursor --headless` or a Windsurf CLI subcommand).
 
 **Quick start with opentelemetry-hooks:**
 
@@ -197,9 +199,12 @@ For agents that emit no OpenTelemetry data, use **[opentelemetry-hooks](https://
 # Install
 pip install opentelemetry-hooks
 
-# Wrap any unsupported agent
-otel-hooks --service-name cursor --otlp-endpoint http://localhost:4317 -- cursor <args>
+# Wrap CLI-based agents (full coverage)
 otel-hooks --service-name aider  --otlp-endpoint http://localhost:4317 -- aider <args>
+otel-hooks --service-name opencode --otlp-endpoint http://localhost:4317 -- opencode <args>
+
+# Wrap GUI-based agents (launch/exit coverage only)
+otel-hooks --service-name cursor --otlp-endpoint http://localhost:4317 -- cursor <args>
 ```
 
 **What opentelemetry-hooks captures:**
@@ -210,13 +215,15 @@ otel-hooks --service-name aider  --otlp-endpoint http://localhost:4317 -- aider 
 | Metrics | Wall-clock duration, exit code, process CPU/memory |
 | Logs | stdout/stderr lines as log records with `severity` |
 
-| Agent | Recommended Approach |
-|-------|---------------------|
-| **OpenCode** | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) (primary); community plugin: [opencode-plugin-otel](https://github.com/DEVtheOPS/opencode-plugin-otel) as fallback. Feature request: [#14697](https://github.com/anomalyco/opencode/issues/14697) |
-| **Cursor** | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks); MCP servers (Traceloop, Observe) instrument only user code, not Cursor itself |
-| **Windsurf** | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks); Windsurf agent skills can add OTel to user code but Windsurf itself emits nothing |
-| **Amazon Q Developer** | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks); CloudWatch/CloudTrail for activity logging but no OTLP export |
-| **Aider** | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks); replaces the manual shell-script wrapper approach |
+> **Privacy warning:** Capturing stdout/stderr as logs can include prompts, source code, configuration, secrets (for example, API keys or tokens), and other sensitive data. Before enabling this, review your data-handling requirements and configure your OpenTelemetry pipeline or `opentelemetry-hooks` to disable or redact stdout/stderr capture where needed (for example, via log filtering/redaction or by turning off log export). See [§6. Privacy & Cardinality Considerations](#6-privacy--cardinality-considerations) for guidance.
+
+| Agent | Hooks Support | Recommended Approach |
+|-------|--------------|---------------------|
+| **OpenCode** | CLI-based ✅ | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) (primary); community plugin: [opencode-plugin-otel](https://github.com/DEVtheOPS/opencode-plugin-otel) as fallback. Feature request: [#14697](https://github.com/anomalyco/opencode/issues/14697) |
+| **Cursor** | GUI-first ⚠️ | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) wraps the launch process (launch/exit coverage only); MCP servers (Traceloop, Observe) instrument only user code, not Cursor itself. Wrapping provides limited value unless a CLI/headless mode is used. |
+| **Windsurf** | GUI-first ⚠️ | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) wraps the launch process (launch/exit coverage only); Windsurf agent skills can add OTel to user code but Windsurf itself emits nothing. Wrapping provides limited value unless a CLI subcommand is used. |
+| **Amazon Q Developer** | CLI-based ✅ | Native: CloudWatch/CloudTrail for activity logging, no built-in OTLP export. For process-level OTLP signals from the Q Developer CLI process, wrap it with [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks). |
+| **Aider** | CLI-based ✅ | [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks); replaces the manual shell-script wrapper approach |
 
 ---
 
@@ -510,7 +517,7 @@ Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123
 
 **Action**: Watch the [Qwen Code changelog](https://qwenlm.github.io/qwen-code-docs/en/developers/development/telemetry/) and the repo for the enabling commit. Do not build infrastructure dependencies on Qwen Code telemetry until code ships.
 
-### 7.4 Agents With No OTel Support (OpenCode, Cursor, Windsurf, Amazon Q, Aider)
+### 7.4 Agents With No OTel Support (OpenCode, Cursor, Windsurf, Amazon Q Developer, Aider)
 
 **Gap**: These agents emit no OTLP data. Native instrumentation is absent and no roadmap items are public.
 


### PR DESCRIPTION
For all AI coding agents without native OTel support (OpenCode, Cursor, Windsurf, Amazon Q Developer, Aider), recommend
https://github.com/o11y-dev/opentelemetry-hooks as the primary instrumentation approach.

- §2.7: rewritten to lead with opentelemetry-hooks quick-start and per-agent recommendation table
- §7.4: new Known Gap entry covering all five unsupported agents with opentelemetry-hooks as workaround and capability limitations note
- §7.5/7.6: renumbered to accommodate new section

https://claude.ai/code/session_018AxyMPPXs4fNcr5eNGPFzZ