### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, limitations, and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Clarify hook support and governance in AI agent observability reference
+- Document limitations, roadmap, and contribution guidelines in README, CONTRIBUTING, and this changelog
 
 ## [1.2.0] - 2026-03-20
 
@@ -41,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Initial cognitive router (`SKILL.md`) with System 2 Thinking framework
-- 12 progressive disclosure triggers mapping to reference documents
+- 11 progressive disclosure triggers mapping to reference documents
 - Reference documents: architecture, collector, instrumentation, sampling, security, monitoring, OTTL, platforms
 - Anti-pattern prevention with explicit language (MUST/NEVER/ALWAYS)
 - TDD testing framework with rationalization table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+- Clarify hook support and governance in AI agent observability reference
+
+## [1.2.0] - 2026-03-20
+
+### Added
+- AI coding agent observability reference (`references/ai-agents.md`) with support matrix for Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, and others
+- Recommend opentelemetry-hooks for agents without native telemetry
+- Production playbooks routing reference from OpenTelemetry.io blog series (`references/playbooks.md`)
+- 5 new test scenarios for AI agent observability
+
+### Fixed
+- Homepage references and installation URLs
+
+## [1.1.0] - 2026-03-11
+
+### Added
+- Connectors reference (`references/connectors.md`): spanmetrics, servicegraph, routing, failover with stickiness requirements
+- Kafka resiliency patterns, semconv v1.30+ guidance, config management, scaling guidance (Collector v0.147.0)
+- Upstream maintenance digest workflow (weekly automated scan of OTel issues, releases, and blog posts)
+- Cursor Marketplace plugin manifests
+- Markdownlint configuration for documentation style
+- Filesystem compatibility warnings for `file_storage` and bbolt
+- Document semconv handling for intentional HTTP cancellations
+- Load-balancing routing key requirements and Go SDK 1.40.0 breaking changes
+
+### Changed
+- README trimmed: removed Terraform comparison table, fixed installation URLs
+- Applied upstream maintenance guidance from 2026-02-24 digest
+- bbolt v1.4.3 on_rebound crash mitigation documented
+
+## [1.0.0] - 2026-02-03
+
+### Added
+- Initial cognitive router (`SKILL.md`) with System 2 Thinking framework
+- 12 progressive disclosure triggers mapping to reference documents
+- Reference documents: architecture, collector, instrumentation, sampling, security, monitoring, OTTL, platforms
+- Anti-pattern prevention with explicit language (MUST/NEVER/ALWAYS)
+- TDD testing framework with rationalization table
+- Claude marketplace plugin (`.claude-plugin/marketplace.json`)
+- CI validation workflow (frontmatter, links, markdown linting)
+- Auto-delete merged branches workflow
+- Contrib component references and example configs
+- Per-language SDK links and instrumentation packaging guidance
+
+[Unreleased]: https://github.com/o11y-dev/opentelemetry-skill/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/o11y-dev/opentelemetry-skill/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/o11y-dev/opentelemetry-skill/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/o11y-dev/opentelemetry-skill/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ SKILL.md (cognitive router, ~compact)
     |-- trigger: "collector"  --> references/collector.md
     |-- trigger: "sampling"   --> references/sampling.md
     |-- trigger: "OTTL"       --> references/ottl.md
-    |-- ... (12 triggers total)
+    |-- ... (11 triggers total)
     |
 references/ (loaded only when triggered)
 tests/ (TDD validation scenarios)
@@ -64,12 +64,12 @@ To add a test:
 
 ## CI validation
 
-`.github/workflows/validate.yml` checks on every push and PR:
+`.github/workflows/validate.yml` runs on a subset of paths for pushes and PRs (it may not run on every push/PR):
 
 - `SKILL.md` has required frontmatter (`name`, `description`)
-- `marketplace.json` structure is valid
-- No broken internal links between `SKILL.md` and `references/`
-- Markdown linting passes
+- `.claude-plugin/marketplace.json` structure is valid
+- Referenced files between `SKILL.md` and `references/` exist (basic internal link check; anchors are not validated)
+- Markdown linting runs in non-blocking mode (`continue-on-error: true`; failures do not fail CI)
 
 ## Commit conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to opentelemetry-skill
+
+## What this project is
+
+This is an AI skill, not traditional software. `SKILL.md` is a cognitive router that teaches LLMs how to reason about OpenTelemetry before generating code. The `references/` directory contains deep-dive documents loaded on demand via progressive disclosure triggers.
+
+```
+SKILL.md (cognitive router, ~compact)
+    |
+    |-- trigger: "Kubernetes" --> references/architecture.md
+    |-- trigger: "collector"  --> references/collector.md
+    |-- trigger: "sampling"   --> references/sampling.md
+    |-- trigger: "OTTL"       --> references/ottl.md
+    |-- ... (12 triggers total)
+    |
+references/ (loaded only when triggered)
+tests/ (TDD validation scenarios)
+```
+
+## How to contribute
+
+### Adding or updating a reference document
+
+Reference documents live in `references/`. Each one covers a specific domain of OpenTelemetry.
+
+1. Use production-first language: MUST, NEVER, ALWAYS where safety matters
+2. Include anti-patterns with explicit "why this breaks" explanations
+3. Include version-specific notes (e.g., "requires Collector v0.147.0+")
+4. Keep configuration examples complete and runnable
+5. Reference upstream docs with links
+
+### Adding a new progressive disclosure trigger
+
+Triggers are defined in `SKILL.md` and map keywords to reference files.
+
+1. Identify a gap: what question does the AI answer poorly without this trigger?
+2. Add the trigger keyword pattern to `SKILL.md`
+3. Create or update the corresponding reference document
+4. Add test scenarios in `tests/` that validate the trigger fires correctly
+5. Update `README.md` if the trigger covers a new domain
+
+### Adding test scenarios
+
+Tests live in `tests/` and follow the RED-GREEN-REFACTOR pattern:
+
+1. `tests/rationalization-table.md` tracks discovered AI "excuses" (shortcuts the AI takes)
+2. `tests/compliance-verification.md` validates that anti-rationalizations work
+3. `tests/ai-agent-scenarios.md` covers AI agent observability scenarios
+
+To add a test:
+1. Identify a rationalization (a shortcut or wrong answer the AI gives)
+2. Add it to the rationalization table with the counter-instruction
+3. Embed the counter directly into `SKILL.md` where the rationalization occurs
+4. Add a scenario that would trigger the rationalization and verify it's blocked
+
+### Updating playbooks
+
+`references/playbooks.md` routes upstream OpenTelemetry blog posts by technical problem.
+
+1. Find a new blog post on [opentelemetry.io/blog](https://opentelemetry.io/blog)
+2. Identify which technical problem it addresses
+3. Add it to the routing table with: title, URL, technical intent, and related triggers
+4. The weekly upstream maintenance workflow (`otel-upstream-maintenance.yml`) will flag new posts automatically
+
+## CI validation
+
+`.github/workflows/validate.yml` checks on every push and PR:
+
+- `SKILL.md` has required frontmatter (`name`, `description`)
+- `marketplace.json` structure is valid
+- No broken internal links between `SKILL.md` and `references/`
+- Markdown linting passes
+
+## Commit conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` - new reference, trigger, or capability
+- `fix:` - correction to existing content
+- `docs:` - documentation improvements
+- `test:` - new or updated test scenarios
+- `ci:` - workflow changes
+
+## PR expectations
+
+- One logical change per PR
+- CI validation passes
+- If adding a reference: include at least one test scenario
+- If updating `SKILL.md` triggers: explain what question this improves
+- Open an issue first for structural changes (new trigger categories, testing framework changes)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ This skill is designed to evolve with the OpenTelemetry ecosystem. Contributions
 3. **Expand Examples**: Language-specific SDK patterns
 4. **Improve Triggers**: Refine the progressive disclosure logic
 
+## Known Limitations
+
+- **AI agent trace coverage varies**: Claude Code does not emit traces natively; observability relies on [opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) or native logs/metrics. Each agent has different signal coverage.
+- **Tail sampling memory**: Scales with in-flight trace count. Beyond 10k RPS, consider tiered architecture (Agent -> Gateway -> Analysis) rather than single-collector tail sampling.
+- **OTTL regex transforms**: Can impact p99 latency at high span volume. Profile with production traffic before deploying regex-heavy transformations.
+- **Semantic conventions are evolving**: The `gen_ai.*` namespace is experimental. Attribute names may change in future OpenTelemetry releases.
+- **Kubernetes version requirements**: Native sidecar container support requires v1.24+. Earlier versions need traditional sidecar patterns.
+
+## Roadmap
+
+- Expand AI agent observability coverage as new agents ship native telemetry (Qwen Code, Windsurf, Zed)
+- Track OpenTelemetry semantic convention releases for `gen_ai` namespace stabilization
+- Add cost optimization patterns for high-volume agent deployments
+- Expand production playbook coverage with new upstream blog posts
+- Add eBPF-based collection patterns for auto-instrumentation
+- Collector processor stability matrix tracking across releases
+
 ## Compatibility
 
 - **OpenTelemetry Collector**: v0.147.0+


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` covering v1.0.0 through v1.2.0 with grouped milestones and version comparison links
- Add `CONTRIBUTING.md` explaining the progressive disclosure architecture, how to add triggers/references/tests/playbooks, and CI validation
- Add **Known Limitations** section to README (tail sampling memory, OTTL regex perf, gen_ai semconv stability, agent trace coverage gaps)
- Add **Roadmap** section to README (new agent coverage, semconv tracking, cost optimization, eBPF patterns)

## Why

The skill is at v1.2.0 with 11 reference documents and 12 progressive disclosure triggers but no changelog, no contributor guide, and no explicit documentation of limitations or future direction. These additions make the project more approachable for contributors and transparent about what it can and can't do today.

## Test plan

- [ ] Verify CHANGELOG version links resolve correctly on GitHub
- [ ] Verify CONTRIBUTING instructions are accurate against current project structure
- [ ] Verify CI validation passes (markdown lint, link checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)