### PR TITLE
fix: improve Tessl review visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Clarify hook support and governance in AI agent observability reference
 - Document limitations, roadmap, and contribution guidelines in README, CONTRIBUTING, and this changelog
-- Refresh compatibility defaults in `SKILL.md` to Collector v0.150.0+ and Python SDK v1.41.0+
+- Make bundled references and evaluation docs review-visible via a Tessl docs entrypoint
+- Move fast-changing compatibility details out of `SKILL.md` and into `references/compatibility.md`
 - Add practical upstream watch guidance for bbolt security advisory tracking and event-to-logs proposal maturity
 
 ## [1.2.0] - 2026-03-20

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the source code for the **OpenTelemetry Skill** tile re
 
 ## Key Features
 
-**Comprehensive Coverage**: 11 specialized reference docs covering OpenTelemetry ecosystem components
+**Comprehensive Coverage**: Specialized reference docs covering collector architecture, security, sampling, AI agents, and compatibility
 
 **Production Focus**: Emphasizes stability, security, and cost optimization patterns
 
@@ -70,12 +70,12 @@ Unlike loading the entire OpenTelemetry documentation into an AI's context (whic
 
 ## Skill Structure
 
-`SKILL.md` acts as the **cognitive router** — a compact instruction set that tells the AI how to reason about observability before generating any output. The `references/` directory contains deep-dive documentation that is loaded on demand when specific topics are triggered, keeping context lean and focused.
+`SKILL.md` acts as the **cognitive router** — a compact instruction set that tells the AI how to reason about observability before generating any output. `docs/index.md` is the tile's on-demand documentation entrypoint for Tessl, and `references/` contains the deep-dive documents that the skill links to when specific topics are triggered.
 
 ### 📊 **Content Overview**
 
-- **7,851 lines** of OpenTelemetry guidance across 11 specialized reference docs
-- **12 AI coding agents** tracked with upstream monitoring  
+- **Packaged reference docs** for architecture, collector design, instrumentation, security, sampling, AI agents, and compatibility
+- **AI coding agent coverage** tracked with upstream monitoring  
 - **Production-tested** configurations with validation commands
 - **Current & updated** - automatically synced with latest OpenTelemetry releases
 
@@ -122,11 +122,14 @@ opentelemetry-skill/
 ├── .cursor-plugin/
 │   ├── marketplace.json      # Cursor marketplace metadata
 │   └── plugin.json           # Cursor plugin manifest
+├── docs/
+│   └── index.md              # Tessl docs entrypoint for bundled references and eval assets
 ├── SKILL.md                  # Cognitive router (the "brain")
 ├── README.md                 # This file
 ├── references/
 │   ├── ai-agents.md          # AI agent observability patterns & configurations
 │   ├── architecture.md       # Deployment patterns & scaling
+│   ├── compatibility.md      # Version-sensitive support and compatibility notes
 │   ├── collector.md          # Pipeline configuration & components
 │   ├── instrumentation.md    # SDKs & semantic conventions
 │   ├── sampling.md           # Sampling strategies
@@ -230,9 +233,10 @@ The OpenTelemetry Collector Contrib repository contains extended components and 
 
 This skill includes a comprehensive test and validation framework following TDD (Test-Driven Development) principles:
 
-- **[tests/baseline-scenarios.md](tests/baseline-scenarios.md)**: RED phase - Test scenarios to run WITHOUT skill to establish baseline behavior
-- **[tests/compliance-verification.md](tests/compliance-verification.md)**: GREEN phase - Verify skill changes agent behavior as expected
-- **[tests/rationalization-table.md](tests/rationalization-table.md)**: REFACTOR phase - Document and counter agent rationalizations
+- **Structured Tessl evals** live in [`evals/`](evals/README.md) and are the canonical published scenarios
+- **[tests/baseline-scenarios.md](tests/baseline-scenarios.md)**: RED phase support document for baseline behavior capture
+- **[tests/compliance-verification.md](tests/compliance-verification.md)**: GREEN phase support document for verifying behavior changes
+- **[tests/rationalization-table.md](tests/rationalization-table.md)**: REFACTOR phase log of agent rationalizations and counters
 
 The testing framework validates that the skill actually changes AI behavior and doesn't allow common anti-patterns. GitHub Actions automatically validates skill structure and content on every change, and the Tessl report workflow posts best-practice review feedback on every pull request.
 
@@ -266,11 +270,7 @@ This skill is designed to evolve with the OpenTelemetry ecosystem. Contributions
 
 ## Compatibility
 
-- **OpenTelemetry Collector**: v0.150.0+
-- **Semantic Conventions**: v1.40.0+
-- **Kubernetes**: v1.24+ (for native sidecar support)
-- **Go SDK**: v1.24.0+
-- **Python SDK**: v1.40.0+
+Compatibility details move faster than the cognitive-router guidance in `SKILL.md`. See [`references/compatibility.md`](references/compatibility.md) for the current version floors and AI agent support notes.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,11 +31,11 @@ Always adhere to these guiding principles:
 
 Before generating any configuration or code, verify these critical factors. If any are undefined, ask the user:
 
-1. **Signal volume** — High-traffic (>10k RPS) vs low-volume? Determines sampling and scaling needs. → Load `references/sampling.md`, `references/collector.md`
-2. **Cardinality risk** — Any unbounded attributes (user IDs, request IDs, session IDs) in metrics? Force those to traces/logs instead. → Load `references/instrumentation.md`
-3. **Resiliency** — Can you tolerate data loss during restarts/outages? If not, enable `file_storage` + persistent queues. → Load `references/collector.md`
-4. **Trust boundaries** — Signals crossing public networks? Require TLS + mTLS. → Load `references/security.md`
-5. **Deployment target** — Kubernetes (DaemonSet/Deployment), EC2, Lambda, or containers? → Load `references/architecture.md`
+1. **Signal volume** — High-traffic (>10k RPS) vs low-volume? Determines sampling and scaling needs. → Load [sampling.md](references/sampling.md), [collector.md](references/collector.md)
+2. **Cardinality risk** — Any unbounded attributes (user IDs, request IDs, session IDs) in metrics? Force those to traces/logs instead. → Load [instrumentation.md](references/instrumentation.md)
+3. **Resiliency** — Can you tolerate data loss during restarts/outages? If not, enable `file_storage` + persistent queues. → Load [collector.md](references/collector.md)
+4. **Trust boundaries** — Signals crossing public networks? Require TLS + mTLS. → Load [security.md](references/security.md)
+5. **Deployment target** — Kubernetes (DaemonSet/Deployment), EC2, Lambda, or containers? → Load [architecture.md](references/architecture.md)
 
 ## Progressive Disclosure: Context Triggers
 
@@ -43,19 +43,17 @@ Load detailed reference documentation only when the user's request matches a tri
 
 | Trigger keywords | Load | Key topics |
 |---|---|---|
-| Kubernetes, Helm, DaemonSet, Sidecar, Gateway, Scaling, Load Balancing | `references/architecture.md` | DaemonSet vs Gateway vs Sidecar, Target Allocator, HPA |
-| Pipeline, Receiver, Processor, Exporter, Queue, Batch, Memory, Extensions | `references/collector.md` | Processor ordering, memory_limiter, file_storage, stability levels |
-| SDK, Instrumentation, Spans, Attributes, Semantic Conventions, Cardinality | `references/instrumentation.md` | Auto vs manual, SemConv, cardinality Rule of 100 |
-| Sampling, Cost, Volume, Head Sampling, Tail Sampling, Probabilistic | `references/sampling.md` | Head/tail sampling, sticky sessions, sampling math |
-| Security, PII, GDPR, Redaction, TLS, Authentication, Credentials | `references/security.md` | PII redaction, mTLS, RBAC, extension exposure risks |
-| Monitor the collector, Health, Alerts, Self-monitoring, Collector metrics | `references/monitoring.md` | otelcol_* metrics, dashboards, alert rules |
-| Lambda, Azure Functions, GCP Functions, Serverless, FaaS, Mobile, Browser | `references/platforms.md` | FaaS patterns, Lambda extension layer, client-side apps |
-| OTTL, Transform, Transformation, Modify, Filter attributes, Parse, Extract | `references/ottl.md` | OTTL syntax, context types, built-in functions, error handling |
-| Connector, spanmetrics, servicegraph, routing connector, failover connector | `references/connectors.md` | R.E.D. metrics, service graph, routing, failover, stickiness |
-| Claude Code, Codex, Gemini CLI, Copilot, AI agent, coding agent, MCP | `references/ai-agents.md` | Agent OTel support matrix, unified collector config, GenAI SemConv |
-| playbook, production playbook, blog, 2025 blog, 2026 blog, real world | `references/playbooks.md` | Production patterns from opentelemetry.io blogs |
-
-> **Collector `loadbalancing` exporter tip**: `routing_key` must be a stable, low-cardinality string (`traceID`, `tenant_id`, `cluster`). Normalize non-string attributes to strings before routing to prevent shard churn.
+| Kubernetes, Helm, DaemonSet, Sidecar, Gateway, Scaling, Load Balancing | [architecture.md](references/architecture.md) | DaemonSet vs Gateway vs Sidecar, Target Allocator, HPA |
+| Pipeline, Receiver, Processor, Exporter, Queue, Batch, Memory, Extensions | [collector.md](references/collector.md) | Processor ordering, memory_limiter, file_storage, stability levels |
+| SDK, Instrumentation, Spans, Attributes, Semantic Conventions, Cardinality | [instrumentation.md](references/instrumentation.md) | Auto vs manual, SemConv, cardinality Rule of 100 |
+| Sampling, Cost, Volume, Head Sampling, Tail Sampling, Probabilistic | [sampling.md](references/sampling.md) | Head/tail sampling, sticky sessions, sampling math |
+| Security, PII, GDPR, Redaction, TLS, Authentication, Credentials | [security.md](references/security.md) | PII redaction, mTLS, RBAC, extension exposure risks |
+| Monitor the collector, Health, Alerts, Self-monitoring, Collector metrics | [monitoring.md](references/monitoring.md) | otelcol_* metrics, dashboards, alert rules |
+| Lambda, Azure Functions, GCP Functions, Serverless, FaaS, Mobile, Browser | [platforms.md](references/platforms.md) | FaaS patterns, Lambda extension layer, client-side apps |
+| OTTL, Transform, Transformation, Modify, Filter attributes, Parse, Extract | [ottl.md](references/ottl.md) | OTTL syntax, context types, built-in functions, error handling |
+| Connector, spanmetrics, servicegraph, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness |
+| Claude Code, Codex, Gemini CLI, Copilot, AI agent, coding agent, MCP | [ai-agents.md](references/ai-agents.md) | Agent OTel support matrix, unified collector config, GenAI SemConv |
+| playbook, production playbook, blog, 2025 blog, 2026 blog, real world | [playbooks.md](references/playbooks.md) | Production patterns from opentelemetry.io blogs |
 
 ## Production Baseline Configuration
 
@@ -187,12 +185,5 @@ curl -s http://localhost:8888/metrics | grep -E "otelcol_processor_dropped|otelc
 
 ## Version and Compatibility
 
-- **Target Version**: OpenTelemetry Collector v0.150.0+ (2026+)
-- **Semantic Conventions**: v1.40.0+
-- **Kubernetes**: v1.24+ (for native sidecar support)
-- **Go SDK**: v1.24.0+
-- **Python SDK**: v1.41.0+
-- **Claude Code Telemetry**: Compatible with current release (metrics + logs/events)
-- **Gemini CLI Telemetry**: v0.34.0+ (traces + metrics + logs, GenAI SemConv)
-- **GitHub Copilot OTel**: VS Code Insiders / latest stable (traces + metrics + events, GenAI SemConv)
-- **Codex CLI Telemetry**: v0.105.0+ (traces + logs in interactive mode; exec/mcp-server gaps)
+- Use [compatibility.md](references/compatibility.md) for fast-moving version floors and AI agent support details.
+- Keep `SKILL.md` focused on routing logic, guardrails, and production defaults rather than inline release tracking.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# OpenTelemetry Skill Tile Documentation
+
+This document is the Tessl docs entrypoint for the tile. `SKILL.md` remains the cognitive router for agent behavior, while this index makes the bundled references, evaluation assets, and project guidance explicitly review-visible.
+
+## Reference bundles
+
+These are the deep-dive documents that the skill loads on demand:
+
+- [AI agents](../references/ai-agents.md)
+- [Architecture](../references/architecture.md)
+- [Collector](../references/collector.md)
+- [Compatibility](../references/compatibility.md)
+- [Connectors](../references/connectors.md)
+- [Instrumentation](../references/instrumentation.md)
+- [Monitoring](../references/monitoring.md)
+- [OTTL](../references/ottl.md)
+- [Platforms](../references/platforms.md)
+- [Playbooks](../references/playbooks.md)
+- [Sampling](../references/sampling.md)
+- [Security](../references/security.md)
+
+## Evaluation surface
+
+The authoritative Tessl-facing eval assets live in `evals/`. The `tests/` documents are supporting methodology notes for the RED/GREEN/REFACTOR workflow.
+
+### Published eval assets
+
+- [Evals overview](../evals/README.md)
+- [Core scenarios](../evals/core-scenarios.md)
+- [AI agent scenarios](../evals/ai-agent-scenarios.md)
+- [Production scenarios](../evals/production-scenarios.md)
+- [Collector memory limiter task](../evals/collector-memory-limiter/task.md)
+- [Cardinality protection task](../evals/cardinality-protection/task.md)
+- [Tail sampling setup task](../evals/tail-sampling-setup/task.md)
+- [Claude Code telemetry task](../evals/claude-code-telemetry/task.md)
+
+### Supporting test methodology
+
+- [Baseline scenarios](../tests/baseline-scenarios.md)
+- [AI agent test scenarios](../tests/ai-agent-scenarios.md)
+- [Compliance verification](../tests/compliance-verification.md)
+- [Rationalization table](../tests/rationalization-table.md)
+
+## Project docs
+
+- [README](../README.md)
+- [Changelog](../CHANGELOG.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/references/compatibility.md
+++ b/references/compatibility.md
@@ -1,0 +1,24 @@
+# Compatibility Reference
+
+Use this document for version-sensitive guidance that changes more frequently than the core routing logic in `SKILL.md`.
+
+## Baseline version floors
+
+- **OpenTelemetry Collector**: v0.150.0+
+- **Semantic Conventions**: v1.40.0+
+- **Kubernetes**: v1.24+ for native sidecar support
+- **Go SDK**: v1.24.0+
+- **Python SDK**: v1.41.0+
+
+## AI agent telemetry compatibility
+
+- **Claude Code**: current release emits metrics plus logs/events, not traces
+- **Gemini CLI**: v0.34.0+ emits traces, metrics, and logs with GenAI semantic conventions
+- **GitHub Copilot**: latest stable / Insiders builds expose traces, metrics, and events with GenAI semantic conventions
+- **Codex CLI**: v0.105.0+ emits traces and logs in interactive mode, with gaps in `exec` / `mcp-server`
+
+## Maintenance guidance
+
+- Treat these version floors as fast-moving compatibility notes rather than hard-coded architectural rules.
+- Pin collector components to released versions and verify stability levels before using non-stable features in production.
+- Re-check upstream release notes whenever updating examples that depend on AI agent telemetry support or evolving semantic conventions.

--- a/tile.json
+++ b/tile.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "private": false,
   "summary": "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot).",
+  "docs": "docs/index.md",
   "skills": {
     "opentelemetry-skill": {
       "path": "SKILL.md"


### PR DESCRIPTION
## Summary
- add a Tessl docs entrypoint so bundled references, eval assets, and supporting docs are review-visible from the manifest
- tighten `SKILL.md` by converting reference mentions into real links, removing duplicate routing guidance, and moving fast-changing compatibility notes into `references/compatibility.md`
- clarify that `evals/` is the canonical Tessl-facing eval surface while `tests/` remains supporting RED/GREEN/REFACTOR methodology

## Validation
- `tessl tile lint`
- `tessl eval run .`
- Eval run: `019df2a5-605b-779f-980e-1121bbaa271f`
