### PR TITLE
Add metrics-specific collector audit guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-08
+
+### Added
+- `references/anti-patterns.md`: full annotated catalog of 17 anti-patterns organized by category (pipeline, Kubernetes, metrics, AI agents, OTTL)
+- Progressive Disclosure trigger for `anti-patterns.md` in `SKILL.md`
+
 ### Changed
+- Teach the skill to audit existing collector/Helm configs for cross-field contradictions such as memory limiter sizing, sticky routing for scaled tail sampling, hostPort misuse, durability gaps, rollout inconsistency, OTTL type drift, unsafe RWX/NFS-backed queues, and risky temporality conversions
+- Trim `SKILL.md` inline anti-patterns from 17 to 6 most critical; remaining 11 moved to `references/anti-patterns.md`
 - Clarify hook support and governance in AI agent observability reference
 - Document limitations, roadmap, and contribution guidelines in README, CONTRIBUTING, and this changelog
 - Make bundled references and evaluation docs review-visible via a Tessl docs entrypoint
 - Move fast-changing compatibility details out of `SKILL.md` and into `references/compatibility.md`
 - Add practical upstream watch guidance for bbolt security advisory tracking and event-to-logs proposal maturity
-- Teach the skill to audit existing collector/Helm configs for cross-field contradictions such as memory limiter sizing, sticky routing for scaled tail sampling, hostPort misuse, durability gaps, rollout inconsistency, OTTL type drift, unsafe RWX/NFS-backed queues, and risky temporality conversions
 
 ## [1.2.0] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Make bundled references and evaluation docs review-visible via a Tessl docs entrypoint
 - Move fast-changing compatibility details out of `SKILL.md` and into `references/compatibility.md`
 - Add practical upstream watch guidance for bbolt security advisory tracking and event-to-logs proposal maturity
+- Teach the skill to audit existing collector/Helm configs for cross-field contradictions such as memory limiter sizing, sticky routing for scaled tail sampling, hostPort misuse, durability gaps, rollout inconsistency, OTTL type drift, unsafe RWX/NFS-backed queues, and risky temporality conversions
 
 ## [1.2.0] - 2026-03-20
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ opentelemetry-skill/
 - ✅ Suggests alternative: "Use user_id as a trace attribute instead, and create a metric for aggregated user counts."
 - ✅ Loads `references/instrumentation.md` to explain cardinality management
 
+### Example 4: Reviewing Existing Helm Values
+
+**User**: "Review this collector Helm values file and tell me what's risky."
+
+**AI Response**:
+- ✅ Audits cross-field contradictions, not just YAML syntax
+- ✅ Compares `memory_limiter` settings to container memory limits
+- ✅ Flags scaled `tail_sampling` without sticky routing
+- ✅ Questions `hostPort` on gateway Deployments
+- ✅ Calls out retry/queue durability gaps, unsafe RWX/EFS-backed `file_storage`, and rollout-setting conflicts
+- ✅ Audits metrics temporality conversions such as `deltatocumulative` when restart or scaling behavior would make the state unsafe
+- ✅ Corrects OTTL type mismatches and stale semantic convention keys
+
 See [`SKILL.md`](SKILL.md) for the full list of progressive disclosure triggers, System 2 thinking signals, core principles, and production-ready configuration defaults.
 
 ## Reference Documentation

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: "Expert OpenTelemetry guidance for collector configuration, pipelin
 license: Apache-2.0
 metadata:
   author: o11y.dev
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # OpenTelemetry Skill

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,8 @@ Always adhere to these guiding principles:
 
 7. **Security by Default**: Redact PII, enable TLS for cross-network communication, and authenticate all collector endpoints.
 
+8. **Cross-Field Consistency**: Treat collector reviews as systems reviews, not YAML linting. Compare processor order, memory limits, replica strategy, routing, metric temporality state, queue storage medium, PDB/HPA settings, and OTTL attribute types together before calling a config "safe".
+
 ## Pre-Flight Checklist
 
 Before generating any configuration or code, verify these critical factors. If any are undefined, ask the user:
@@ -37,14 +39,30 @@ Before generating any configuration or code, verify these critical factors. If a
 4. **Trust boundaries** — Signals crossing public networks? Require TLS + mTLS. → Load [security.md](references/security.md)
 5. **Deployment target** — Kubernetes (DaemonSet/Deployment), EC2, Lambda, or containers? → Load [architecture.md](references/architecture.md)
 
+## Existing Configuration Review Mode
+
+When the user provides an existing collector config, Helm values file, or Kubernetes manifest, audit it for internal contradictions before proposing edits.
+
+Always compare:
+
+1. **Memory limiter vs pod limit** — `limit_mib` must stay below the container memory limit with headroom for the Go runtime and internal buffers.
+2. **Stateful processing vs scaling** — `tail_sampling`, `spanmetrics`, and `servicegraph` require sticky routing when replicas can exceed 1.
+3. **Exporter durability vs outage tolerance** — disabled retries and no persistent queue imply data loss during backend failures.
+4. **Network exposure vs deployment mode** — `hostPort` is usually a DaemonSet/node-local choice, not a horizontally scaled gateway Deployment default.
+5. **Rollout settings together** — review `replicaCount`, HPA `minReplicas`, PodDisruptionBudget, and rolling update settings as one unit.
+6. **OTTL/filter correctness** — keep attribute types consistent (for example bool vs string) and prefer current semantic convention keys such as `http.response.status_code`.
+7. **Dead config** — flag processors/exporters/extensions that are declared but never referenced by any pipeline.
+8. **Metric temporality and state** — `deltatocumulative` / `cumulativetodelta` are stateful conversions; verify source temporality, backend expectations, restart tolerance, and any replica/routing assumptions before enabling them.
+9. **Queue storage backend** — `file_storage` needs local locking-safe storage; `ReadWriteMany` / EFS / NFS-style volumes are not safe defaults.
+
 ## Progressive Disclosure: Context Triggers
 
 Load detailed reference documentation only when the user's request matches a trigger. This keeps context lean.
 
 | Trigger keywords | Load | Key topics |
 |---|---|---|
-| Kubernetes, Helm, DaemonSet, Sidecar, Gateway, Scaling, Load Balancing | [architecture.md](references/architecture.md) | DaemonSet vs Gateway vs Sidecar, Target Allocator, HPA |
-| Pipeline, Receiver, Processor, Exporter, Queue, Batch, Memory, Extensions | [collector.md](references/collector.md) | Processor ordering, memory_limiter, file_storage, stability levels |
+| Kubernetes, Helm, values.yaml, audit, review, DaemonSet, Sidecar, Gateway, Scaling, Load Balancing | [architecture.md](references/architecture.md) | DaemonSet vs Gateway vs Sidecar, Target Allocator, HPA, rollout consistency |
+| Pipeline, Receiver, Processor, Exporter, Queue, Batch, Memory, Extensions, existing config | [collector.md](references/collector.md) | Processor ordering, memory_limiter, file_storage, config audit heuristics, temporality/state audits, stability levels |
 | SDK, Instrumentation, Spans, Attributes, Semantic Conventions, Cardinality | [instrumentation.md](references/instrumentation.md) | Auto vs manual, SemConv, cardinality Rule of 100 |
 | Sampling, Cost, Volume, Head Sampling, Tail Sampling, Probabilistic | [sampling.md](references/sampling.md) | Head/tail sampling, sticky sessions, sampling math |
 | Security, PII, GDPR, Redaction, TLS, Authentication, Credentials | [security.md](references/security.md) | PII redaction, mTLS, RBAC, extension exposure risks |
@@ -125,7 +143,7 @@ Key defaults:
 
 - `memory_limiter` must be first in every processor chain.
 - `batch` reduces exporter network calls.
-- `file_storage` preserves queues across restarts only when the collector returns to the same host/volume. In Kubernetes, back `/var/lib/otelcol/queue` with a PVC.
+- `file_storage` preserves queues across restarts only when the collector returns to the same host/volume. In Kubernetes, back `/var/lib/otelcol/queue` with a `ReadWriteOnce` block-backed PVC rather than RWX/network storage.
 - `health_check` binds to `localhost` (not `0.0.0.0`) in shared networks.
 - Prefer OTLP gRPC (port 4317) for receivers and exporters. Fall back to OTLP HTTP (port 4318) when gRPC is unavailable.
 
@@ -176,12 +194,18 @@ curl -s http://localhost:8888/metrics | grep -E "otelcol_processor_dropped|otelc
 ❌ Exposing pprof (1777), zpages (55679) on `0.0.0.0` in production
 ❌ Using `tail_sampling` without sticky session load balancing (loadbalancing exporter)
 ❌ Omitting `batch` processor (causes excessive network calls)
+❌ Calling a config "fine" because it parses, without checking memory limits, sticky routing, exporter durability, and rollout settings together
+❌ Using `hostPort` on a horizontally scaled gateway Deployment without a clear node-local traffic requirement
+❌ Setting `memory_limiter.limit_mib` above the pod/container memory limit or with no runtime headroom
+❌ Converting metrics with `deltatocumulative` / `cumulativetodelta` without checking source temporality, backend expectations, and restart/scale behavior
+❌ Backing `file_storage` queues with RWX/network filesystems (EFS/NFS/CephFS) as if they were local disks
 ❌ Including `prompt.id` or `session.id` as metric dimensions (unbounded cardinality)
 ❌ Enabling `captureContent`/`OTEL_LOG_USER_PROMPTS` in shared/production environments without PII controls
 ❌ Assuming all AI coding agents emit traces (Claude Code and Codex exec do not)
 ❌ Using delta temporality with backends that expect cumulative (e.g., VictoriaMetrics silently drops)
 ❌ Hard-coding `gen_ai.token.type` handling to only `input`/`output` values
 ❌ Treating open spec proposals as stable APIs before they ship in SDKs/collector releases
+❌ Mixing OTTL/filter attribute types (for example, setting a boolean then matching it with `IsMatch(..., "true")`) or drifting back to legacy keys like `http.status_code`
 
 ## Version and Compatibility
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -72,6 +72,7 @@ Load detailed reference documentation only when the user's request matches a tri
 | Connector, spanmetrics, servicegraph, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness |
 | Claude Code, Codex, Gemini CLI, Copilot, AI agent, coding agent, MCP | [ai-agents.md](references/ai-agents.md) | Agent OTel support matrix, unified collector config, GenAI SemConv |
 | playbook, production playbook, blog, 2025 blog, 2026 blog, real world | [playbooks.md](references/playbooks.md) | Production patterns from opentelemetry.io blogs |
+| anti-pattern, common mistake, what to avoid, pitfall | [anti-patterns.md](references/anti-patterns.md) | Full annotated anti-pattern catalogue: pipeline, metrics, Kubernetes, AI agents, OTTL |
 
 ## Production Baseline Configuration
 
@@ -189,23 +190,14 @@ curl -s http://localhost:8888/metrics | grep -E "otelcol_processor_dropped|otelc
 
 ## Anti-Patterns to Avoid
 
+The most critical patterns are listed here. See [anti-patterns.md](references/anti-patterns.md) for the full annotated catalog.
+
 ❌ Placing `memory_limiter` anywhere except first in the processor chain
 ❌ Using high-cardinality attributes (user_id, trace_id) as metric dimensions
 ❌ Exposing pprof (1777), zpages (55679) on `0.0.0.0` in production
 ❌ Using `tail_sampling` without sticky session load balancing (loadbalancing exporter)
 ❌ Omitting `batch` processor (causes excessive network calls)
 ❌ Calling a config "fine" because it parses, without checking memory limits, sticky routing, exporter durability, and rollout settings together
-❌ Using `hostPort` on a horizontally scaled gateway Deployment without a clear node-local traffic requirement
-❌ Setting `memory_limiter.limit_mib` above the pod/container memory limit or with no runtime headroom
-❌ Converting metrics with `deltatocumulative` / `cumulativetodelta` without checking source temporality, backend expectations, and restart/scale behavior
-❌ Backing `file_storage` queues with RWX/network filesystems (EFS/NFS/CephFS) as if they were local disks
-❌ Including `prompt.id` or `session.id` as metric dimensions (unbounded cardinality)
-❌ Enabling `captureContent`/`OTEL_LOG_USER_PROMPTS` in shared/production environments without PII controls
-❌ Assuming all AI coding agents emit traces (Claude Code and Codex exec do not)
-❌ Using delta temporality with backends that expect cumulative (e.g., VictoriaMetrics silently drops)
-❌ Hard-coding `gen_ai.token.type` handling to only `input`/`output` values
-❌ Treating open spec proposals as stable APIs before they ship in SDKs/collector releases
-❌ Mixing OTTL/filter attribute types (for example, setting a boolean then matching it with `IsMatch(..., "true")`) or drifting back to legacy keys like `http.status_code`
 
 ## Version and Compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ This document is the Tessl docs entrypoint for the tile. `SKILL.md` remains the 
 These are the deep-dive documents that the skill loads on demand:
 
 - [AI agents](../references/ai-agents.md)
+- [Anti-patterns](../references/anti-patterns.md)
 - [Architecture](../references/architecture.md)
 - [Collector](../references/collector.md)
 - [Compatibility](../references/compatibility.md)

--- a/references/anti-patterns.md
+++ b/references/anti-patterns.md
@@ -1,0 +1,149 @@
+# OpenTelemetry Anti-Patterns
+
+This reference catalogs known anti-patterns across collector configuration, metrics design, Kubernetes deployments, and AI agent instrumentation. The top 6 most critical patterns are also kept inline in `SKILL.md`; all patterns are listed here with explanations and mitigations.
+
+---
+
+## Collector Pipeline Anti-Patterns
+
+### `memory_limiter` not first in the processor chain
+
+Placing any other processor before `memory_limiter` allows unchecked memory growth during bursts or back-pressure events, which can silently corrupt in-flight data before the limiter can shed load.
+
+**Fix:** `memory_limiter` must always be the first processor in every pipeline.
+
+---
+
+### Omitting the `batch` processor
+
+Without batching, each span/metric/log is exported individually, producing thousands of small network calls per second and dramatically reducing throughput.
+
+**Fix:** Add `batch` immediately after `memory_limiter` in every pipeline.
+
+---
+
+### Exposing pprof / zpages on `0.0.0.0` in production
+
+`pprof` (port 1777) and `zpages` (port 55679) expose internal profiling and pipeline state. Binding them to all interfaces in a shared network allows any workload to extract sensitive runtime data or profile the collector under load.
+
+**Fix:** Bind debug extensions to `localhost` only, or omit them entirely in production.
+
+---
+
+### Using `tail_sampling` without sticky session load balancing
+
+`tail_sampling` keeps per-trace state in memory. When multiple collector replicas compete for the same traffic without a `loadbalancing` exporter routing upstream, spans from the same trace are split across instances and sampling decisions diverge.
+
+**Fix:** Place a `loadbalancing` exporter (with `routing_key: traceID`) upstream of all `tail_sampling` replicas.
+
+---
+
+### Using high-cardinality attributes as metric dimensions
+
+Attributes such as `user_id`, `trace_id`, `request_id`, and `session_id` are unbounded and will cause metric cardinality explosions, OOM kills in the collector, and cost blowups in the backend.
+
+**Fix:** Use traces or structured logs for high-cardinality data; keep metric dimensions below 100 unique values per attribute (Rule of 100).
+
+---
+
+### Calling a config "fine" because it parses
+
+A config that passes `otelcol validate` can still be operationally broken: memory limits may exceed pod limits, stateful processors may run without sticky routing, queues may be backed by unsafe filesystems, and rollout settings may be mutually contradictory.
+
+**Fix:** Treat every collector review as a systems review, not a YAML lint. Compare memory limits, replica strategy, routing, metric temporality state, queue storage medium, and PDB/HPA settings together.
+
+---
+
+## Kubernetes Deployment Anti-Patterns
+
+### `hostPort` on a horizontally scaled gateway Deployment
+
+`hostPort` reserves a port on every node the pod lands on. This is appropriate for DaemonSets where exactly one pod runs per node, but counter-productive and fragile on a Deployment that can schedule multiple replicas anywhere.
+
+**Fix:** Use a `ClusterIP` or `LoadBalancer` Service instead. Reserve `hostPort` for DaemonSet node-agent patterns with an explicit justification.
+
+---
+
+### `memory_limiter.limit_mib` exceeding the pod/container memory limit
+
+When the collector's `limit_mib` is higher than the container's `resources.limits.memory`, the Go runtime can allocate beyond the cgroup limit before the limiter fires, causing the container to be OOM-killed with no graceful shedding.
+
+**Fix:** Set `limit_mib` to roughly 80% of the container memory limit to leave headroom for the Go runtime and internal buffers.
+
+---
+
+### Backing `file_storage` queues with RWX/network filesystems
+
+`file_storage` uses bbolt, which requires byte-level file locking via `flock(2)`. EFS, NFS, and CephFS (in network modes) do not provide reliable POSIX locks, leading to database corruption on multi-writer or failover scenarios.
+
+**Fix:** Back `file_storage` with a `ReadWriteOnce` block-backed PVC (for example, `gp3` on EKS). Never use `ReadWriteMany` or NFS-class storage.
+
+---
+
+## Metrics Anti-Patterns
+
+### `deltatocumulative` / `cumulativetodelta` without checking source temporality and backend expectations
+
+These processors are stateful: they accumulate or differentiate metric state in memory. Restarting the collector resets that state, producing a discontinuous series. Running multiple replicas without sticky routing splits the state across instances.
+
+**Fix:** Confirm source SDK temporality, the backend's expected temporality, restart tolerance, and replica routing before enabling temporality conversion processors. Add justification comments in the config.
+
+---
+
+### Using delta temporality with backends that expect cumulative
+
+Some backends (VictoriaMetrics, OpenTSDB) silently drop delta-temporality metrics or misinterpret them as cumulative. The error is silent and data appears to disappear.
+
+**Fix:** Check the backend's temporality contract. Use `deltatocumulative` in the collector if the SDK emits delta and the backend expects cumulative — but see the stateful conversion warning above.
+
+---
+
+## AI Agent Instrumentation Anti-Patterns
+
+### Including `prompt.id` or `session.id` as metric dimensions
+
+These identifiers are unbounded (a new value per agent invocation). Using them as metric label values creates cardinality explosions that degrade the metrics backend and increase cost without insight.
+
+**Fix:** Use `prompt.id` and `session.id` as span/log attributes only, never as metric dimensions.
+
+---
+
+### Enabling `captureContent` / `OTEL_LOG_USER_PROMPTS` without PII controls
+
+These settings log raw prompt and completion text. In shared or production environments this can expose user PII, secrets embedded in prompts, and proprietary code to the telemetry backend.
+
+**Fix:** Keep content capture disabled by default. If required for debugging, enable only in isolated dev/staging environments with appropriate data governance controls.
+
+---
+
+### Assuming all AI coding agents emit traces
+
+Claude Code and Codex-exec do not emit traces — they emit metrics and logs/events only. Configuring a traces pipeline as the sole signal path will silently discard all their telemetry.
+
+**Fix:** Check the AI agent support matrix in [compatibility.md](compatibility.md) before designing the collector pipeline. Always include a metrics and logs pipeline alongside any traces pipeline.
+
+---
+
+### Hard-coding `gen_ai.token.type` handling to only `input`/`output` values
+
+The GenAI semantic conventions include additional token type values (for example `cache_read`, `cache_creation`). Hard-coding only `input`/`output` silently drops cost attribution for cached tokens.
+
+**Fix:** Use a default/catch-all branch for unknown `gen_ai.token.type` values rather than strict equality checks.
+
+---
+
+### Treating open-spec proposals as stable APIs before they ship in SDKs or collector releases
+
+GenAI and AI agent SemConv proposals move quickly. Implementing attributes from draft proposals means breaking changes when the spec stabilizes.
+
+**Fix:** Check the stability status in [compatibility.md](compatibility.md) before using new attributes in production instrumentation.
+
+---
+
+## OTTL / Transform Anti-Patterns
+
+### Mixing OTTL attribute types or using legacy semantic convention keys
+
+OTTL is strictly typed. Setting an attribute to a boolean and then matching it with `IsMatch(..., "true")` will silently fail. Using deprecated keys like `http.status_code` instead of `http.response.status_code` produces gaps when backends apply semantic convention normalization.
+
+**Fix:** Use `Int()`, `String()`, `Bool()` converters explicitly in OTTL statements. Use current SemConv keys and validate with `otelcol validate`.

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -265,6 +265,16 @@ spec:
 ✅ **Resource over-provisioning** - Gateway handles bursts; set limits 2-4x requests
 ✅ **HPA on memory** - Collector memory usage is often the bottleneck
 ✅ **Health checks** - Always configure liveness and readiness probes
+✅ **Prefer Services over `hostPort` for gateways** - Reserve `hostPort` for node-local/DaemonSet use cases; on scaled Deployments it constrains scheduling and often fights the HPA
+✅ **Validate rollout settings together** - `replicas`, HPA `minReplicas`, PodDisruptionBudget, and `maxUnavailable` must all be satisfiable during startup and voluntary disruptions
+
+### Deployment Sanity Checks
+
+Review these together before calling a gateway Deployment production-ready:
+
+1. **Replica math**: Avoid a PodDisruptionBudget that requires more available pods than the Deployment can guarantee during startup or maintenance windows.
+2. **Tail sampling stickiness**: If HPA can scale the gateway above one replica, upstream routing must already be sticky; scaling a stateful gateway behind a normal Service breaks correctness.
+3. **Port exposure**: A gateway exposed via ClusterIP, LoadBalancer, or Ingress usually does not need `hostPort`. Using `hostPort` on a multi-replica Deployment means only one pod can bind a given port per node.
 
 ---
 

--- a/references/collector.md
+++ b/references/collector.md
@@ -9,14 +9,15 @@ The OpenTelemetry Collector is a vendor-agnostic telemetry pipeline that receive
 1. [Pipeline Anatomy](#pipeline-anatomy)
 2. [Core vs Contrib Components](#core-vs-contrib-components)
 3. [Processor Ordering: The Critical Path](#processor-ordering-the-critical-path)
-4. [Memory Limiter: Preventing OOM Kills](#memory-limiter-preventing-oom-kills)
-5. [Persistent Queues: Preventing Data Loss](#persistent-queues-preventing-data-loss)
-6. [Resiliency: Message Queues (Kafka)](#resiliency-message-queues-kafka)
-7. [Batch Processor: Network Optimization](#batch-processor-network-optimization)
-8. [Extensions](#extensions)
-9. [Configuration Management](#configuration-management)
-10. [Configuration Patterns](#configuration-patterns)
-11. [Component Docs & Example Configs](#component-docs--example-configs)
+4. [Component Docs & Example Configs](#component-docs--example-configs)
+5. [Auditing Existing Collector Configurations](#auditing-existing-collector-configurations)
+6. [Memory Limiter: Preventing OOM Kills](#memory-limiter-preventing-oom-kills)
+7. [Persistent Queues: Preventing Data Loss](#persistent-queues-preventing-data-loss)
+8. [Resiliency: Message Queues (Kafka)](#resiliency-message-queues-kafka)
+9. [Batch Processor: Network Optimization](#batch-processor-network-optimization)
+10. [Extensions](#extensions)
+11. [Configuration Management](#configuration-management)
+12. [Configuration Patterns](#configuration-patterns)
 
 ---
 
@@ -323,6 +324,138 @@ Browse the [examples/ directory](https://github.com/open-telemetry/opentelemetry
 
 ---
 
+## Auditing Existing Collector Configurations
+
+When reviewing an existing collector config or Helm values file, do more than syntax validation. Most production failures come from **cross-field contradictions** that still parse successfully.
+
+### Review Checklist
+
+| Check | What to compare | Why it matters |
+|-------|-----------------|----------------|
+| **Processor chain** | `memory_limiter` first, `batch` near the end, every declared processor referenced by a pipeline | Correct ordering prevents OOMs and wasted work; unreferenced processors create dead config that misleads reviewers |
+| **Memory envelope** | `memory_limiter.limit_mib` / `limit_percentage` vs container memory limit | A limiter above the pod limit cannot protect the collector from cgroup OOM kills |
+| **Stateful processing** | `tail_sampling`, `spanmetrics`, `servicegraph` vs replica count/HPA and routing | Stateful processors break when traces/related spans are split across replicas |
+| **Metric temporality/state** | `deltatocumulative`, `cumulativetodelta`, source temporality, backend expectation, and replica/restart behavior | Temporality conversion is stateful; restarts or non-sticky routing can create resets or incorrect cumulative series |
+| **Exporter durability** | `retry_on_failure`, `sending_queue`, `file_storage`, and stated outage tolerance | No retry + no queue means guaranteed loss during backend or network faults |
+| **Queue storage backend** | `file_storage` access mode, storage class, and whether the filesystem is local vs RWX/networked | Persistent queues need locking-safe local block storage; EFS/NFS/RWX can corrupt or stall queue state |
+| **OTTL/filter correctness** | Attribute names, types, nil guards, and regex use | Real-world breakages often come from bool-vs-string mismatches or stale semantic convention keys |
+| **Kubernetes rollout consistency** | `replicaCount`, HPA `minReplicas`, PodDisruptionBudget, `maxUnavailable`, and `hostPort` usage | Valid YAML can still be unschedulable, non-evictable, or incompatible with scaled Deployments |
+
+### Common Audit Findings
+
+#### 1. Memory limiter larger than the pod limit
+
+```yaml
+# Bad: collector will hit the container limit first
+resources:
+  limits:
+    memory: 666Mi
+
+processors:
+  memory_limiter:
+    limit_mib: 1500
+    spike_limit_mib: 512
+```
+
+```yaml
+# Better: leave runtime headroom and let the limiter trigger first
+resources:
+  limits:
+    memory: 2Gi
+
+processors:
+  memory_limiter:
+    limit_percentage: 80
+    spike_limit_percentage: 20
+```
+
+**Rule**: Keep the limiter below the pod limit and reserve roughly 15-30% for Go runtime overhead, queues, and transient buffers.
+
+#### 2. Tail sampling on scaled gateways without sticky routing
+
+If a Deployment can scale above one replica, a regular ClusterIP Service is **not enough** for `tail_sampling`. You need an upstream `loadbalancing` exporter with `routing_key: traceID` and a Headless Service for the gateway tier. Otherwise traces fragment across pods and sampling decisions are wrong.
+
+#### 3. Retry disabled and no durable queue
+
+If `retry_on_failure.enabled: false` and there is no `sending_queue` backed by `file_storage`, the collector will drop data whenever the backend is unavailable. Treat this as an explicit durability trade-off that needs confirmation, not as a neutral default.
+
+#### 4. OTTL/filter type mismatches
+
+```yaml
+# Bad: writes a boolean, later treats it as a regex target string
+transform/flag:
+  trace_statements:
+    - context: span
+      statements:
+        - set(attributes["is_error"], true) where attributes["http.response.status_code"] >= 400
+
+filter/drop:
+  traces:
+    span:
+      - not IsMatch(attributes["is_error"], "true")
+```
+
+```yaml
+# Better: compare booleans as booleans
+filter/drop:
+  traces:
+    span:
+      - attributes["is_error"] != true
+```
+
+Also prefer current semantic convention keys such as `http.response.status_code` over legacy ad hoc names like `http.status_code`.
+
+#### 5. Metric temporality conversion without a state plan
+
+```yaml
+processors:
+  deltatocumulative:
+    max_stale: 1m
+
+service:
+  pipelines:
+    metrics:
+      processors: [deltatocumulative, batch]
+
+autoscaling:
+  enabled: true
+  maxReplicas: 6
+```
+
+`deltatocumulative` and `cumulativetodelta` keep per-timeseries state in memory. On restart, scale-out, or whenever a timeseries lands on a different replica, the converted series can reset or become inconsistent. Only use them when:
+
+- the source temporality is known,
+- the backend expectation is known,
+- and the routing/restart behavior makes the reset semantics acceptable.
+
+On generic OTLP gateway tiers, prefer matching source temporality to backend expectations instead of converting in the middle unless you have a clear reason to do otherwise.
+
+#### 6. `file_storage` on RWX or network filesystems
+
+A queue is not "durable" just because it writes to disk. The `file_storage` extension uses bbolt and needs local locking-safe storage. In Kubernetes, treat these as audit findings:
+
+- `ReadWriteMany` PVCs
+- EFS / NFS / SMB / CephFS-backed storage classes
+- designs that imply multiple pods share the same queue directory
+
+Prefer per-replica `ReadWriteOnce` block volumes. See the filesystem compatibility notes in [Persistent Queues: Preventing Data Loss](#persistent-queues-preventing-data-loss).
+
+#### 7. Dead config
+
+A processor/exporter/extension that is declared but unused is not harmless documentation. It creates false confidence during reviews because operators assume the behavior is active. During audits, verify every named component appears in at least one pipeline or `service.extensions`.
+
+### Audit Questions to Ask Explicitly
+
+1. Is data loss during backend outages acceptable here?
+2. Can this collector ever run more than one replica?
+3. What is the actual pod memory limit, and does the limiter stay below it?
+4. Is `hostPort` intentionally required for node-local traffic, or is a normal Service sufficient?
+5. Are the transform/filter expressions using the same attribute names and types end-to-end?
+6. Are temporality-conversion processors (`deltatocumulative` / `cumulativetodelta`) actually required, and can their per-timeseries state survive this routing/scaling model?
+7. Is `file_storage` backed by a local block volume (`ReadWriteOnce`), not RWX/network storage?
+
+---
+
 ## Memory Limiter: Preventing OOM Kills
 
 The `memory_limiter` is the **single most important processor** for collector stability.
@@ -353,6 +486,8 @@ processors:
 2. **Reserve for OS overhead** (e.g., 200 MiB)
 3. **Set limit_mib** = Container limit - Reserve = 1848 MiB
 4. **Set spike_limit_mib** = 20% of limit = ~370 MiB
+
+⚠️ **Never set `limit_mib` above the pod/container memory limit.** If the cgroup limit is lower than the memory limiter threshold, Kubernetes kills the process before the collector can apply backpressure or forced GC.
 
 **Example**:
 

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -394,21 +394,11 @@ exporters:
   otlp:
     retry_on_failure:
       enabled: false
-processors_extra:
-  transform/flag:
-    trace_statements:
-      - context: span
-        statements:
-          - set(attributes["2metric"], true) where attributes["http.status_code"] != "200"
-  filter/lambda:
-    traces:
-      span:
-        - name == "Lambda.Invoke" and not IsMatch(attributes["2metric"], "true")
 ```
 
 ### Expected Baseline Behavior (WITHOUT skill)
 - May point out one or two obvious issues
-- **Likely SKIPS:** cross-field review of memory sizing, sticky routing, `hostPort`, rollout consistency, and OTTL type mismatches
+- **Likely SKIPS:** cross-field review of memory sizing, sticky routing, `hostPort`, and rollout consistency
 - **Likely RATIONALIZES:** "The YAML looks mostly fine; just tune some values"
 
 ### Target Behavior (WITH skill)
@@ -417,7 +407,6 @@ processors_extra:
 - Flags `hostPort` as suspicious for a scaled gateway Deployment
 - Flags `retry_on_failure: false` with no durable queue as an explicit data-loss trade-off
 - Flags rollout inconsistency across `replicaCount`, HPA, and PodDisruptionBudget
-- Flags OTTL/filter mismatch: boolean attribute checked via string regex and stale `http.status_code` usage
 - References collector.md and architecture.md audit guidance
 
 ### Success Criteria
@@ -425,7 +414,6 @@ processors_extra:
 - [ ] Agent identifies sticky-routing requirement for tail sampling
 - [ ] Agent questions or rejects `hostPort` on this gateway deployment
 - [ ] Agent identifies durability risk from disabled retry / missing queue
-- [ ] Agent identifies OTTL type or semantic-convention mismatch
 - [ ] Agent reviews rollout settings as a combined system, not independent fields
 
 ---
@@ -464,7 +452,7 @@ service:
       processors: [deltatocumulative, filter/drop_http, memory_limiter, batch]
 extensions:
   file_storage/queue:
-    directory: /var/lib/storage/queue/coralogix
+    directory: /var/lib/storage/queue
 exporters:
   otlp:
     sending_queue:

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -362,6 +362,148 @@ I need to redact all email addresses from span attributes using OTTL.
 
 ---
 
+## Scenario 11: Existing Helm Values Audit
+
+**Objective:** Verify agent audits an existing collector values file for cross-field contradictions instead of only fixing syntax.
+
+### Test Prompt
+```yaml
+Review this OpenTelemetry Collector Helm values snippet and tell me what's risky or inconsistent:
+
+mode: deployment
+replicaCount: 1
+autoscaling:
+  enabled: true
+  minReplicas: 4
+processors:
+  tail_sampling:
+    decision_wait: 5s
+    num_traces: 1000
+  memory_limiter:
+    limit_mib: 1500
+resources:
+  limits:
+    memory: 666Mi
+ports:
+  otlp:
+    hostPort: 4317
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+exporters:
+  otlp:
+    retry_on_failure:
+      enabled: false
+processors_extra:
+  transform/flag:
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["2metric"], true) where attributes["http.status_code"] != "200"
+  filter/lambda:
+    traces:
+      span:
+        - name == "Lambda.Invoke" and not IsMatch(attributes["2metric"], "true")
+```
+
+### Expected Baseline Behavior (WITHOUT skill)
+- May point out one or two obvious issues
+- **Likely SKIPS:** cross-field review of memory sizing, sticky routing, `hostPort`, rollout consistency, and OTTL type mismatches
+- **Likely RATIONALIZES:** "The YAML looks mostly fine; just tune some values"
+
+### Target Behavior (WITH skill)
+- Flags that `memory_limiter.limit_mib` exceeds pod memory limit and should leave runtime headroom
+- Flags `tail_sampling` on a Deployment that can scale above one replica without sticky routing/loadbalancing exporter
+- Flags `hostPort` as suspicious for a scaled gateway Deployment
+- Flags `retry_on_failure: false` with no durable queue as an explicit data-loss trade-off
+- Flags rollout inconsistency across `replicaCount`, HPA, and PodDisruptionBudget
+- Flags OTTL/filter mismatch: boolean attribute checked via string regex and stale `http.status_code` usage
+- References collector.md and architecture.md audit guidance
+
+### Success Criteria
+- [ ] Agent compares memory limiter settings to pod memory limits
+- [ ] Agent identifies sticky-routing requirement for tail sampling
+- [ ] Agent questions or rejects `hostPort` on this gateway deployment
+- [ ] Agent identifies durability risk from disabled retry / missing queue
+- [ ] Agent identifies OTTL type or semantic-convention mismatch
+- [ ] Agent reviews rollout settings as a combined system, not independent fields
+
+---
+
+## Scenario 12: Existing Metrics Helm Values Audit
+
+**Objective:** Verify agent audits metrics-specific state, storage, and processor-ordering risks in an existing collector values file.
+
+### Test Prompt
+```yaml
+Review this OpenTelemetry Collector metrics Helm values snippet and tell me what's risky or inconsistent:
+
+mode: statefulset
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 6
+processors:
+  groupbyattrs/keep_stable_labels:
+    keys: [cloud.region, faas.name, k8s.deployment.name]
+  deltatocumulative:
+    max_stale: 1m
+  memory_limiter:
+    limit_mib: 1500
+resources:
+  limits:
+    memory: 666Mi
+service:
+  pipelines:
+    metrics:
+      processors: [deltatocumulative, filter/drop_http, memory_limiter, batch]
+extensions:
+  file_storage/queue:
+    directory: /var/lib/storage/queue/coralogix
+exporters:
+  otlp:
+    sending_queue:
+      enabled: true
+      storage: file_storage/queue
+statefulset:
+  volumeClaimTemplates:
+    - metadata:
+        name: queue
+      spec:
+        storageClassName: efs
+        accessModes: [ReadWriteMany]
+ports:
+  otlp:
+    hostPort: 4317
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
+### Expected Baseline Behavior (WITHOUT skill)
+- May praise the presence of a persistent queue
+- **Likely SKIPS:** that `deltatocumulative` is stateful, that EFS/RWX is unsafe for `file_storage`, that `memory_limiter` is not first, and that `groupbyattrs` is declared but unused
+- **Likely RATIONALIZES:** "It already has a queue, so it's mostly production-ready"
+
+### Target Behavior (WITH skill)
+- Flags that `memory_limiter.limit_mib` exceeds the pod memory limit and is placed too late in the metrics processor chain
+- Flags `deltatocumulative` as a stateful temporality conversion that needs source/backend justification and careful restart/scale assumptions
+- Flags `file_storage` on `efs` + `ReadWriteMany` as unsafe for bbolt-backed persistent queues
+- Flags `groupbyattrs/keep_stable_labels` as dead config because it is declared but unused
+- Questions `hostPort` on a horizontally scalable metrics gateway
+- Notes that `podDisruptionBudget.minAvailable: 1` with a single guaranteed replica prevents voluntary eviction unless that trade-off is intentional
+- References collector.md audit guidance and persistent-queue filesystem guidance
+
+### Success Criteria
+- [ ] Agent compares memory limiter settings to pod memory limits
+- [ ] Agent flags `memory_limiter` ordering in the metrics pipeline
+- [ ] Agent identifies temporality conversion as stateful and questions whether it is needed
+- [ ] Agent identifies EFS/RWX as unsafe for `file_storage`
+- [ ] Agent flags declared-but-unused `groupbyattrs`
+- [ ] Agent questions `hostPort` or PDB settings in the scaled/single-replica design
+
+---
+
 ## Running These Tests
 
 ### Step 1: Prepare Test Environment
@@ -412,7 +554,7 @@ Each rationalization gets an explicit counter added to SKILL.md.
 ### Success Metrics
 
 For skill to be considered "passing TDD":
-- [ ] **10/10 scenarios** show clear behavior change WITH skill vs baseline
+- [ ] **12/12 scenarios** show clear behavior change WITH skill vs baseline
 - [ ] Agent uses skill content (decision matrices, patterns, checklists)
 - [ ] Agent doesn't rationalize skipping best practices
 - [ ] Rationalizations documented and countered in skill
@@ -429,10 +571,12 @@ For skill to be considered "passing TDD":
 8. **Custom attribute names instead of semantic conventions** (Scenario 8)
 9. **Missing persistent queues** (Scenario 9)
 10. **Inefficient OTTL transformations** (Scenario 10)
+11. **No audit of cross-field config contradictions** (Scenario 11)
+12. **No audit of metrics temporality/storage contradictions** (Scenario 12)
 
 ### RED Phase Complete When:
 
-- [ ] All 10 scenarios run WITHOUT skill
+- [ ] All 12 scenarios run WITHOUT skill
 - [ ] Results documented in `baseline-results/` directory
 - [ ] Rationalizations captured verbatim
 - [ ] Comparison criteria defined for GREEN phase

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -448,6 +448,11 @@ processors:
     keys: [cloud.region, faas.name, k8s.deployment.name]
   deltatocumulative:
     max_stale: 1m
+  filter/drop_http:
+    error_mode: ignore
+    metrics:
+      datapoint:
+        - 'attributes["http.route"] == ""'
   memory_limiter:
     limit_mib: 1500
 resources:

--- a/tests/compliance-verification.md
+++ b/tests/compliance-verification.md
@@ -278,6 +278,69 @@ Look for agent:
 
 ---
 
+## Scenario 11: Existing Helm Values Audit
+
+### Expected Improvements
+
+**Baseline → Compliance Changes:**
+- Agent NOW audits the snippet as a whole system instead of line-by-line
+- Agent compares `memory_limiter` to container limits
+- Agent requires sticky routing for scaled tail sampling
+- Agent questions `hostPort` on a gateway Deployment
+- Agent identifies retry/queue durability gaps
+- Agent catches the bool-vs-string OTTL/filter mismatch and stale semantic convention key
+
+### Success Criteria Verification
+
+- [ ] Agent compares memory limiter settings to pod memory limits
+- [ ] Agent calls out sticky-routing requirement for `tail_sampling`
+- [ ] Agent flags `hostPort` as suspicious or inappropriate here
+- [ ] Agent identifies disabled retry / missing queue as data-loss risk
+- [ ] Agent catches OTTL type mismatch or stale `http.status_code`
+- [ ] Agent evaluates HPA/PDB/replica settings together
+
+### Evidence Checklist
+
+Look for agent:
+- Mentioning that `limit_mib: 1500` conflicts with `memory: 666Mi`
+- Explaining that scaling `tail_sampling` behind a normal Service breaks correctness
+- Saying `hostPort` is usually for node-local / DaemonSet patterns, not gateway Deployments
+- Recommending `sending_queue` + `file_storage` when data loss is not acceptable
+- Correcting `http.status_code` to `http.response.status_code` and/or bool-vs-string comparison
+
+---
+
+## Scenario 12: Existing Metrics Helm Values Audit
+
+### Expected Improvements
+
+**Baseline → Compliance Changes:**
+- Agent NOW audits the metrics snippet as a stateful system, not just a queue-enabled config
+- Agent flags `memory_limiter` size and ordering problems
+- Agent questions whether `deltatocumulative` is required and explains its restart/scale trade-offs
+- Agent rejects `file_storage` on `efs` + `ReadWriteMany`
+- Agent catches dead config (`groupbyattrs`) and rollout/eviction concerns
+
+### Success Criteria Verification
+
+- [ ] Agent compares memory limiter settings to pod memory limits
+- [ ] Agent flags `memory_limiter` ordering in the metrics pipeline
+- [ ] Agent identifies temporality conversion as stateful and questions whether it is needed
+- [ ] Agent identifies EFS/RWX as unsafe for `file_storage`
+- [ ] Agent flags declared-but-unused `groupbyattrs`
+- [ ] Agent questions `hostPort` or PDB settings in the scaled/single-replica design
+
+### Evidence Checklist
+
+Look for agent:
+- Mentioning that `limit_mib: 1500` conflicts with `memory: 666Mi`
+- Calling out that `memory_limiter` should be first, not after other metric processors
+- Explaining that `deltatocumulative` keeps per-timeseries state and can reset on restart/scale events
+- Saying `ReadWriteMany` + `efs` is unsafe for bbolt-backed `file_storage`
+- Identifying `groupbyattrs/keep_stable_labels` as unused
+
+---
+
 ## Overall Compliance Assessment
 
 ### Passing Criteria
@@ -285,9 +348,9 @@ Look for agent:
 Skill is considered "passing GREEN phase" when:
 
 **Quantitative:**
-- [ ] 10/10 scenarios show measurable behavior improvement
+- [ ] 12/12 scenarios show measurable behavior improvement
 - [ ] 80%+ of success criteria met across all scenarios
-- [ ] Agent references skill content in 9/10+ scenarios
+- [ ] Agent references skill content in 11/12+ scenarios
 
 **Qualitative:**
 - [ ] Agent proactively applies patterns (not reactive)
@@ -332,7 +395,7 @@ Create file: `compliance-results/scenario-N-[name].md`
 Create file: `compliance-results/SUMMARY.md`
 
 **Include:**
-- Overview: N/10 scenarios passed
+- Overview: N/12 scenarios passed
 - Success criteria: N% met overall
 - Key improvements observed
 - Remaining gaps
@@ -342,7 +405,7 @@ Create file: `compliance-results/SUMMARY.md`
 
 ## GREEN Phase Complete When:
 
-- [ ] All 10 scenarios run WITH skill loaded
+- [ ] All 12 scenarios run WITH skill loaded
 - [ ] Results documented in `compliance-results/` directory
 - [ ] Comparison to baseline complete for all scenarios
 - [ ] Success criteria evaluated
@@ -357,6 +420,6 @@ After GREEN phase:
 1. → `rationalization-table.md` - Update with findings
 2. → REFACTOR phase - Add counters to SKILL.md for new rationalizations
 3. → Re-test scenarios that failed or partially passed
-4. → Iterate until 10/10 scenarios pass
+4. → Iterate until 12/12 scenarios pass
 
-**This is iterative:** First pass may only get 7/10 scenarios passing. That's expected. The goal is continuous improvement through the RED-GREEN-REFACTOR cycle.
+**This is iterative:** First pass may only get 9/12 scenarios passing. That's expected. The goal is continuous improvement through the RED-GREEN-REFACTOR cycle.

--- a/tests/rationalization-table.md
+++ b/tests/rationalization-table.md
@@ -99,11 +99,11 @@ This table tracks agent "excuses" discovered during RED/GREEN testing phases and
 
 **Date:** 2026-01-31
 
-**Scenarios Tested:** 0/12 (Baseline creation)
+**Scenarios Tested:** 0/10 (Baseline creation)
 
 **Findings:**
 - Created baseline scenarios based on common OpenTelemetry pitfalls
-- Identified 12 critical patterns to test
+- Identified 10 critical patterns to test
 - Added OTTL language support with comprehensive reference
 
 **Actions Taken:**
@@ -205,7 +205,7 @@ When a new rationalization is discovered, add it to SKILL.md using this format:
 
 | Iteration | Scenarios Passed | Avg Rationalizations per Scenario | New Rationalizations Found |
 |-----------|------------------|-----------------------------------|----------------------------|
-| 1 (Baseline) | 0/12 | N/A | 12 (initial set) |
+| 1 (Baseline) | 0/10 | N/A | 10 (initial set) |
 | 2 | TBD | TBD | TBD |
 | 3 | TBD | TBD | TBD |
 | ... | ... | ... | ... |

--- a/tests/rationalization-table.md
+++ b/tests/rationalization-table.md
@@ -24,6 +24,8 @@ This table tracks agent "excuses" discovered during RED/GREEN testing phases and
 | Semantic Conventions | "Here's how to add those attributes" | Core Principle #2: Convention over Configuration | ✅ Added |
 | Persistence | "Use retry configuration" | Core Principle #4: Persistent queues for production | ✅ Added |
 | OTTL Performance | "Here's the transformation" | OTTL trigger: Performance considerations | ✅ Added |
+| Existing Config Audit | "The YAML parses, so it's mostly fine" | Core Principle #8 + config review mode: audit cross-field contradictions | ✅ Added |
+| Metrics Config Audit | "It already has a persistent queue, so it's production-ready" | Existing config review mode + collector audit: verify filesystem safety, temporality/state assumptions, and dead config, not just queue presence | ✅ Added |
 
 ---
 
@@ -97,11 +99,11 @@ This table tracks agent "excuses" discovered during RED/GREEN testing phases and
 
 **Date:** 2026-01-31
 
-**Scenarios Tested:** 0/10 (Baseline creation)
+**Scenarios Tested:** 0/12 (Baseline creation)
 
 **Findings:**
 - Created baseline scenarios based on common OpenTelemetry pitfalls
-- Identified 10 critical patterns to test
+- Identified 12 critical patterns to test
 - Added OTTL language support with comprehensive reference
 
 **Actions Taken:**
@@ -116,7 +118,7 @@ This table tracks agent "excuses" discovered during RED/GREEN testing phases and
 
 **Date:** TBD
 
-**Scenarios Tested:** 0/10
+**Scenarios Tested:** 0/12
 
 **Baseline Results:**
 - Scenario 1: [Result]
@@ -197,13 +199,13 @@ When a new rationalization is discovered, add it to SKILL.md using this format:
 **Measurement:**
 - Count rationalizations per scenario
 - Track reduction over iterations
-- Target: 0 rationalizations in 10/10 scenarios
+- Target: 0 rationalizations in 12/12 scenarios
 
 ### Iteration Tracking
 
 | Iteration | Scenarios Passed | Avg Rationalizations per Scenario | New Rationalizations Found |
 |-----------|------------------|-----------------------------------|----------------------------|
-| 1 (Baseline) | 0/10 | N/A | 10 (initial set) |
+| 1 (Baseline) | 0/12 | N/A | 12 (initial set) |
 | 2 | TBD | TBD | TBD |
 | 3 | TBD | TBD | TBD |
 | ... | ... | ... | ... |


### PR DESCRIPTION
## Summary
- teach the skill to audit metric temporality/state and queue storage backends when reviewing existing collector configs
- expand collector guidance with checks for `deltatocumulative`/`cumulativetodelta`, RWX or network-backed `file_storage`, and related rollout contradictions
- add a new metrics Helm values audit scenario and update README/changelog/rationalization docs to cover the new behavior

## Validation
- `python3` frontmatter and internal-link check for `SKILL.md`
- `npx --yes markdownlint-cli2 SKILL.md README.md 'references/**/*.md' 'tests/**/*.md'