### PR TITLE
improve upstream watcher coverage

### DIFF
--- a/.github/scripts/build-digest.mjs
+++ b/.github/scripts/build-digest.mjs
@@ -3,7 +3,7 @@
 //
 // Usage:
 //   node build-digest.mjs <frequency>
-//     frequency: daily | weekly | monthly (preferred) or tier1 | tier2 | tier3 (legacy)
+//     frequency: daily | weekly | monthly
 //
 // For every repo in the selected frequency this fetches:
 //   - the latest release (via REST /repos/{repo}/releases/latest)
@@ -30,17 +30,11 @@ const WORKFLOW_FILE_BY_FREQUENCY = {
   daily: '.github/workflows/upstream-tier1.yml',
   weekly: '.github/workflows/upstream-tier2.yml',
   monthly: '.github/workflows/upstream-tier3.yml',
-  tier1: '.github/workflows/upstream-tier1.yml',
-  tier2: '.github/workflows/upstream-tier2.yml',
-  tier3: '.github/workflows/upstream-tier3.yml',
 };
 const DISPLAY_NAME_BY_FREQUENCY = {
   daily: 'Daily',
   weekly: 'Weekly',
   monthly: 'Monthly',
-  tier1: 'Tier 1',
-  tier2: 'Tier 2',
-  tier3: 'Tier 3',
 };
 
 const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
@@ -186,17 +180,9 @@ async function main() {
   const frequency = process.argv[2] ?? 'daily';
   const reposCfg = JSON.parse(await fs.readFile(REPOS_FILE, 'utf8'));
   
-  // Handle both new frequency names and legacy tier names for backward compatibility
-  let repos;
-  if (reposCfg.frequencies && reposCfg.frequencies[frequency]) {
-    repos = reposCfg.frequencies[frequency];
-  } else if (reposCfg.legacy?.tiers?.[frequency]) {
-    repos = reposCfg.legacy.tiers[frequency];
-  } else if (reposCfg.tiers && reposCfg.tiers[frequency]) {
-    // Legacy fallback
-    repos = reposCfg.tiers[frequency];
-  } else {
-    console.error(`unknown frequency/tier: ${frequency}`);
+  const repos = reposCfg.frequencies?.[frequency];
+  if (!repos) {
+    console.error(`unknown frequency: ${frequency}`);
     process.exit(1);
   }
 

--- a/.github/scripts/repos.json
+++ b/.github/scripts/repos.json
@@ -66,6 +66,7 @@
         "open-telemetry/opentelemetry-python",
         "open-telemetry/opentelemetry-js",
         "open-telemetry/opentelemetry-dotnet",
+        "open-telemetry/opentelemetry.io",
         "github/copilot-cli",
         "Aider-AI/aider",
         "anysphere/cursor-wiki",

--- a/.github/scripts/repos.json
+++ b/.github/scripts/repos.json
@@ -16,6 +16,7 @@
       "open-telemetry/opentelemetry-python",
       "open-telemetry/opentelemetry-js",
       "open-telemetry/opentelemetry-dotnet",
+      "open-telemetry/opentelemetry.io",
       "github/copilot-cli",
       "Aider-AI/aider",
       "anysphere/cursor-wiki",

--- a/.github/scripts/repos.json
+++ b/.github/scripts/repos.json
@@ -49,56 +49,5 @@
       "open-telemetry/opentelemetry-erlang",
       "open-telemetry/community"
     ]
-  },
-  "legacy": {
-    "tiers": {
-      "tier1": [
-        "open-telemetry/semantic-conventions",
-        "open-telemetry/opentelemetry-collector-contrib"
-      ],
-      "tier2": [
-        "open-telemetry/opentelemetry-collector",
-        "open-telemetry/opentelemetry-collector-releases",
-        "open-telemetry/opentelemetry-operator",
-        "open-telemetry/opentelemetry-proto",
-        "open-telemetry/opentelemetry-go",
-        "open-telemetry/opentelemetry-java",
-        "open-telemetry/opentelemetry-python",
-        "open-telemetry/opentelemetry-js",
-        "open-telemetry/opentelemetry-dotnet",
-        "open-telemetry/opentelemetry.io",
-        "github/copilot-cli",
-        "Aider-AI/aider",
-        "anysphere/cursor-wiki",
-        "anomalyco/opencode",
-        "DEVtheOPS/opencode-plugin-otel",
-        "openai/codex",
-        "google-gemini/gemini-cli",
-        "anthropics/claude-code",
-        "anthropics/skills",
-        "QwenLM/qwen-code",
-        "microsoft/vscode-copilot-chat",
-        "badlogic/pi-mono"
-      ],
-      "tier3": [
-        "open-telemetry/opentelemetry-specification",
-        "open-telemetry/oteps",
-        "open-telemetry/opentelemetry-helm-charts",
-        "open-telemetry/opentelemetry-demo",
-        "open-telemetry/opentelemetry-java-instrumentation",
-        "open-telemetry/opentelemetry-python-contrib",
-        "open-telemetry/opentelemetry-js-contrib",
-        "open-telemetry/opentelemetry-dotnet-contrib",
-        "open-telemetry/opentelemetry-go-instrumentation",
-        "open-telemetry/opentelemetry-lambda",
-        "open-telemetry/opentelemetry-rust",
-        "open-telemetry/opentelemetry-cpp",
-        "open-telemetry/opentelemetry-ruby",
-        "open-telemetry/opentelemetry-php",
-        "open-telemetry/opentelemetry-swift",
-        "open-telemetry/opentelemetry-erlang",
-        "open-telemetry/community"
-      ]
-    }
   }
 }

--- a/.github/upstream-map.yaml
+++ b/.github/upstream-map.yaml
@@ -157,7 +157,7 @@ mappings:
           - "docs/**"
 
   - skill: references/architecture.md
-    topics: [deployment, operator, k8s]
+    topics: [deployment, operator, k8s, documentation]
     watches:
       - repo: open-telemetry/opentelemetry-operator
         paths:
@@ -168,6 +168,11 @@ mappings:
         paths:
           - "charts/opentelemetry-operator/**"
           - "charts/opentelemetry-collector/values.yaml"
+      - repo: open-telemetry/opentelemetry.io
+        paths:
+          - "README.md"
+          - "CHANGELOG.md"
+          - "docs/**"
 
   - skill: references/instrumentation.md
     topics: [instrumentation, sdks, auto-instrumentation]

--- a/.github/upstream-map.yaml
+++ b/.github/upstream-map.yaml
@@ -157,7 +157,7 @@ mappings:
           - "docs/**"
 
   - skill: references/architecture.md
-    topics: [deployment, operator, k8s, documentation]
+    topics: [deployment, operator, k8s, documentation, demo]
     watches:
       - repo: open-telemetry/opentelemetry-operator
         paths:
@@ -173,10 +173,50 @@ mappings:
           - "README.md"
           - "CHANGELOG.md"
           - "docs/**"
+      - repo: open-telemetry/opentelemetry-demo
+        paths:
+          - "README.md"
+          - "CHANGELOG.md"
+          - "docs/**"
+          - "kubernetes/**"
+          - "docker-compose.yml"
 
   - skill: references/instrumentation.md
-    topics: [instrumentation, sdks, auto-instrumentation]
+    topics: [instrumentation, sdks, auto-instrumentation, language-sdks]
     watches:
+      - repo: open-telemetry/opentelemetry-go
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "go.opentelemetry.io/**"
+      - repo: open-telemetry/opentelemetry-java
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "sdk/**"
+          - "api/**"
+      - repo: open-telemetry/opentelemetry-python
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "opentelemetry-sdk/**"
+          - "docs/**"
+      - repo: open-telemetry/opentelemetry-js
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "packages/**"
+      - repo: open-telemetry/opentelemetry-dotnet
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "src/**"
+          - "docs/**"
+      - repo: open-telemetry/opentelemetry-dotnet-contrib
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "src/**"
       - repo: open-telemetry/opentelemetry-python-contrib
         paths:
           - "instrumentation/**"
@@ -194,6 +234,36 @@ mappings:
         paths:
           - "internal/pkg/instrumentation/**"
           - "CHANGELOG.md"
+      - repo: open-telemetry/opentelemetry-rust
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "opentelemetry/**"
+      - repo: open-telemetry/opentelemetry-cpp
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "sdk/**"
+      - repo: open-telemetry/opentelemetry-ruby
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "sdk/**"
+      - repo: open-telemetry/opentelemetry-php
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "src/**"
+      - repo: open-telemetry/opentelemetry-swift
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "Sources/**"
+      - repo: open-telemetry/opentelemetry-erlang
+        paths:
+          - "CHANGELOG.md"
+          - "README.md"
+          - "apps/**"
 
   - skill: references/security.md
     topics: [cve, security, tls, auth]
@@ -248,6 +318,10 @@ mappings:
   - skill: SKILL.md
     topics: [overview, specification, protocol]
     watches:
+      - repo: open-telemetry/oteps
+        paths:
+          - "README.md"
+          - "text/**"
       - repo: open-telemetry/opentelemetry-specification
         paths:
           - "specification/overview.md"


### PR DESCRIPTION
## Summary

Expand upstream source scanning to cover all tracked repos and clean watcher config.

## Changes

- **Add opentelemetry.io**: Website/blog now tracked in weekly digest, mapped to `references/architecture.md`
- **Map all repos**: Closed coverage gap by mapping 14 previously unmapped repos from `repos.json` to skill watchers:
  - Language SDKs (Go, Java, Python, JS, .NET, Rust, C++, Ruby, PHP, Swift, Erlang) → `references/instrumentation.md`
  - `opentelemetry-demo` → `references/architecture.md`
  - `opentelemetry/oteps` → `SKILL.md`
- **Clean config**: Removed duplicated legacy tier blocks, single source of truth is now `frequencies` (daily/weekly/monthly)
- **Update digest builder**: Removed legacy tier name support from `build-digest.mjs`

## Result

Weekly digest now surfaces changes from:
- Core collector & contrib (critical churn)
- All language SDKs
- Cursor Wiki & AI agent tools
- opentelemetry.io website updates
- OTLP specification & protocol changes

No more upstream repos in `repos.json` go unwatched.