### PR TITLE
Bump skill version and tighten evals

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,21 +13,21 @@ metadata:
 
 Use these defaults:
 
-1. **Stability over Features**: Check otelcol-contrib stability (Alpha/Beta/Stable); warn before production use of non-stable components.
+1. **Stability over Features**: Check otelcol-contrib stability (Alpha/Beta/Stable) and warn on non-stable components in production.
 
 2. **Convention over Configuration**: Prefer OpenTelemetry Semantic Conventions over custom attribute names.
 
-3. **Protocol Unification**: Default to **OTLP gRPC** (port 4317); use **OTLP HTTP** (port 4318) when gRPC is unavailable due to agent, proxy, browser, or backend constraints.
+3. **Protocol Unification**: Default to **OTLP gRPC** (4317); use **OTLP HTTP** (4318) when gRPC is blocked by the agent, proxy, browser, or backend.
 
-4. **Deterministic Routing Keys**: For load-balancing exporters, use stable, deterministic routing keys — `traceID` for tail-sampling stickiness, `tenant_id` or `cluster` for tenant/shard routing. Normalize non-string attributes before routing.
+4. **Deterministic Routing Keys**: Use stable routing keys for load-balancing exporters (`traceID` for tail sampling, `tenant_id` or `cluster` for tenant/shard routing). Normalize non-string attributes first.
 
-5. **Safety First**: Prioritize collector stability (memory limiters, persistent queues, backpressure) over data completeness. Dropping data is preferable to crashing the collector.
+5. **Safety First**: Prefer collector stability (memory limiters, persistent queues, backpressure) over completeness. Dropping data is better than crashing the collector.
 
-6. **Cardinality Awareness**: High-cardinality attributes (>100 unique values) must NOT be metric dimensions — use traces or logs instead.
+6. **Cardinality Awareness**: High-cardinality attributes (>100 unique values) must not be metric dimensions; use traces or logs instead.
 
 7. **Security by Default**: Redact PII, enable TLS for cross-network communication, and authenticate all collector endpoints.
 
-8. **Cross-Field Consistency**: Treat collector reviews as systems reviews, not YAML linting. Compare processor order, memory limits, replica strategy, routing, metric temporality state, queue storage medium, PDB/HPA settings, and OTTL attribute types together before calling a config "safe".
+8. **Cross-Field Consistency**: Treat collector reviews as systems reviews. Check processor order, memory limits, replica strategy, routing, metric temporality, queue storage, PDB/HPA settings, and OTTL types together before calling a config safe.
 
 ## Pre-Flight Checklist
 
@@ -53,17 +53,16 @@ When user requests match these patterns, include these points explicitly:
 
 When the user provides an existing collector config, Helm values file, or Kubernetes manifest, audit it for internal contradictions before proposing edits.
 
-Always compare:
+Check these interactions together:
 
-1. **Memory limiter vs pod limit** — `limit_mib` must stay below the container memory limit with headroom for the Go runtime and internal buffers.
-2. **Stateful processing vs scaling** — `tail_sampling`, `spanmetrics`, and `servicegraph` require sticky routing when replicas can exceed 1.
-3. **Exporter durability vs outage tolerance** — disabled retries and no persistent queue imply data loss during backend failures.
-4. **Network exposure vs deployment mode** — `hostPort` is usually a DaemonSet/node-local choice, not a horizontally scaled gateway Deployment default.
-5. **Rollout settings together** — review `replicaCount`, HPA `minReplicas`, PodDisruptionBudget, and rolling update settings as one unit.
-6. **OTTL/filter correctness** — keep attribute types consistent (for example bool vs string) and prefer current semantic convention keys such as `http.response.status_code`.
-7. **Dead config** — flag processors/exporters/extensions that are declared but never referenced by any pipeline.
-8. **Metric temporality and state** — `deltatocumulative` / `cumulativetodelta` are stateful conversions; verify source temporality, backend expectations, restart tolerance, and any replica/routing assumptions before enabling them.
-9. **Queue storage backend** — `file_storage` needs local locking-safe storage; `ReadWriteMany` / EFS / NFS-style volumes are not safe defaults.
+1. **Memory vs pod limit** — `limit_mib` must leave headroom for the Go runtime and buffers.
+2. **Stateful processing vs scaling** — `tail_sampling`, `spanmetrics`, and `servicegraph` need sticky routing above one replica.
+3. **Durability vs outage tolerance** — disabled retries and no persistent queue mean data loss on backend failure.
+4. **Deployment mode vs exposure** — `hostPort` fits DaemonSet/node-local patterns, not scaled gateway Deployments.
+5. **Rollout settings** — review `replicaCount`, HPA `minReplicas`, PodDisruptionBudget, and rolling updates together.
+6. **OTTL/filter correctness** — keep attribute types consistent and prefer current semantic convention keys.
+7. **Metric temporality and state** — `deltatocumulative` / `cumulativetodelta` need source/backend/restart checks.
+8. **Queue storage backend** — `file_storage` needs local locking-safe storage; RWX, EFS, and NFS are unsafe defaults.
 
 ## Progressive Disclosure: Context Triggers
 
@@ -87,7 +86,7 @@ Load detailed reference documentation only when the user's request matches a tri
 
 ## Production Baseline Configuration
 
-Use these defaults unless the user specifies otherwise. This is a copy-paste-ready starting point:
+Use this copy-paste-ready baseline unless the user wants something different:
 
 ```yaml
 extensions:
@@ -155,7 +154,7 @@ Key defaults:
 
 - `memory_limiter` must be first in every processor chain.
 - `batch` reduces exporter network calls.
-- `file_storage` preserves queues across restarts only when the collector returns to the same host/volume. In Kubernetes, back `/var/lib/otelcol/queue` with a `ReadWriteOnce` block-backed PVC rather than RWX/network storage.
+- `file_storage` preserves queues across restarts only on the same host/volume. In Kubernetes, back `/var/lib/otelcol/queue` with a `ReadWriteOnce` block-backed PVC, not RWX/network storage.
 - `health_check` binds to `localhost` (not `0.0.0.0`) in shared networks.
 - Prefer OTLP gRPC (port 4317) for receivers and exporters. Fall back to OTLP HTTP (port 4318) when gRPC is unavailable.
 

--- a/evals/cardinality-protection/criteria.json
+++ b/evals/cardinality-protection/criteria.json
@@ -20,7 +20,7 @@
     {
       "name": "Offers aggregated alternative dimensions",
       "max_score": 15,
-      "description": "The response proposes at least one bounded alternative such as user_type, user_tier, subscription_plan, or similar low-cardinality categorizations that achieve the monitoring goal without cardinality risk."
+      "description": "The response proposes at least one bounded alternative such as user_type, user_tier, subscription_plan, or another low-cardinality aggregate that still answers the monitoring question without adding user_id to metrics."
     },
     {
       "name": "Does not provide metric configuration that includes user_id",

--- a/evals/claude-code-telemetry/criteria.json
+++ b/evals/claude-code-telemetry/criteria.json
@@ -20,7 +20,7 @@
     {
       "name": "Includes privacy controls for prompt and tool logging",
       "max_score": 20,
-      "description": "The response mentions OTEL_LOG_USER_PROMPTS and/or OTEL_LOG_TOOL_DETAILS privacy controls, explaining that prompt content is not logged by default and these flags must be explicitly enabled. Omitting privacy configuration entirely scores zero — this is a key safety concern for the skill."
+      "description": "The response mentions both prompt and tool logging controls (OTEL_LOG_USER_PROMPTS and OTEL_LOG_TOOL_DETAILS), explains that prompts are redacted by default, and warns that either flag should stay off in shared or production environments unless PII controls are in place."
     },
     {
       "name": "Warns about session.id cardinality in metrics",

--- a/evals/core-scenarios.md
+++ b/evals/core-scenarios.md
@@ -36,7 +36,7 @@ Add user_id as a metric dimension to track per-user API latency.
 - **Rejects the request** - explains user_id violates cardinality limits
 - Suggests alternatives: use user_id as trace attribute instead
 - Explains metric explosion risks with unbounded dimensions
-- Offers aggregated alternatives (user_type, user_tier, etc.)
+- Offers aggregated alternatives (user_type, user_tier, subscription_plan, etc.)
 
 ### Failure Modes
 - Accepts the request and provides configuration

--- a/tests/ai-agent-scenarios.md
+++ b/tests/ai-agent-scenarios.md
@@ -143,6 +143,7 @@
 ### Compliance Check
 
 - [ ] States prompts are redacted by default in Claude Code
+- [ ] Addresses `OTEL_LOG_USER_PROMPTS` explicitly
 - [ ] Addresses `OTEL_LOG_TOOL_DETAILS` specifically
 - [ ] Includes or recommends OTTL redaction for tool parameters
 - [ ] Does NOT accidentally suggest enabling prompt logging

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -83,7 +83,7 @@ I want to track request latency as a metric. Add dimensions for:
 - Recommends:
   - Use traces for user_id and request_id
   - Keep only `http.request.method` and `http.response.status_code` in metrics
-  - Or suggest aggregated user count metric
+  - Or suggest bounded aggregates like user_type, user_tier, or subscription_plan
 - References instrumentation.md cardinality section
 
 ### Success Criteria

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "o11y-dev/opentelemetry-skill",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "summary": "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot).",
   "docs": "docs/index.md",


### PR DESCRIPTION
## Summary\n- Bump the packaged skill version to 0.2.5\n- Tighten eval coverage for bounded metric alternatives and Claude Code privacy controls\n- Trim verbose skill wording in core guidance\n\n## Notes\n- No code behavior changes; docs and eval metadata only