### PR TITLE
docs: document OPENCODE_SPAN_ATTRIBUTES for OpenCode plugin

### DIFF
--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -560,6 +560,13 @@ Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123
 
 > ⚠️ opentelemetry-hooks captures process-level signals only (invocation duration, exit code, stdout/stderr). It complements native telemetry, but it cannot observe LLM token usage, model names, or tool calls made inside the agent. For full GenAI observability, advocate for native instrumentation via the agents' issue trackers.
 
+**OpenCode in-process plugin:** Because process-level hooks cannot see OpenCode's internal token usage, model metadata, or tool calls, the community plugin [opencode-plugin-otel](https://github.com/DEVtheOPS/opencode-plugin-otel) instruments OpenCode from inside the process to capture those signals. As of **v1.2.0**, set `OPENCODE_SPAN_ATTRIBUTES` to a comma-separated list of `key=value` pairs that the plugin attaches to every emitted span, log event, and metric data point — useful for filtering or grouping by team or environment in your backend. It is independent of `OPENCODE_RESOURCE_ATTRIBUTES`, which sets producer metadata on the OTel Resource.
+
+```bash
+# Tag every OpenCode span, log event, and metric point for filtering
+export OPENCODE_SPAN_ATTRIBUTES="team=platform,deployment.environment=production"
+```
+
 ### 7.5 Cross-Agent Trace Correlation
 
 **Gap**: No W3C `traceparent` propagation exists between AI coding agents. If Claude Code calls a tool that triggers Gemini CLI (or vice versa via MCP), there is no automatic trace linkage.


### PR DESCRIPTION
## Summary

Documents the `OPENCODE_SPAN_ATTRIBUTES` environment variable in `references/ai-agents.md` (§7.4), added by the community OpenCode OTel plugin. Surfaced via the weekly upstream digest (#85).

Only one P0 item from digest #85 verified as shipped **and** in scope; the rest are deferred with reasons below.

## Verified change (proof)

- **`OPENCODE_SPAN_ATTRIBUTES`** — custom span/metric/log attributes for the OpenCode plugin.
  - Proof: DEVtheOPS/opencode-plugin-otel PR **#67** (`feat(config): support OPENCODE_SPAN_ATTRIBUTES`), merged 2026-06-20, released in **v1.2.0** (release notes list `feat(config): support OPENCODE_SPAN_ATTRIBUTES`). Documented in the plugin README. Closes upstream issue #63.
  - Edit: one additive note in §7.4 (the section that already flags hooks cannot see in-process token/model/tool signals), with the env var, an example, and the distinction from `OPENCODE_RESOURCE_ATTRIBUTES`.

## Deferred — not yet released / out of scope

- **security.md — Collector #15504 (configtls explicit TLS client-auth on ServerConfig)** — still an **open issue**, created 2026-06-26, after v0.155.0 (2026-06-23). Not shipped. No edit.
- **security.md — Collector #15509 (reject auth errors + sender backoff hint)** — still an **open issue**, created 2026-06-29, after v0.155.0. Not shipped. No edit.
- **opencode-plugin-otel #72 (agent name shows "unknown" on Grafana)** — **closed as completed** 2026-06-27 (user confirmed fix via Grafana screenshot; resolved by v1.2.0 `feat(handlers): add agent metadata to logs and spans`, not by PR #73 which was closed unmerged). A fixed bug, not an open known-issue, so no caveat added.
- **claude-code #72248 (Workflow tool delivers JSON args as string) / #72228 (MCP tool calls drop params)** — both **open**, but they are general Claude Code tool/MCP correctness bugs, not OpenTelemetry-instrumentation defects. ai-agents.md documents Claude Code *telemetry* (metrics/logs/events), not Workflow/MCP tool-call mechanics; adding them would mis-scope the reference. No edit.

Source: weekly upstream digest #85 (2026-06-29).
