### PR TITLE
Improve generated metric correctness guidance

### DIFF
--- a/.github/upstream-map.yaml
+++ b/.github/upstream-map.yaml
@@ -75,10 +75,17 @@ mappings:
     priority: critical
     topics: [gen_ai, agents, llm]
     watches:
+      - repo: open-telemetry/semantic-conventions-genai
+        paths:
+          - "model/**"
+          - "docs/**"
+          - "README.md"
+          - "CHANGELOG.md"
       - repo: open-telemetry/semantic-conventions
         paths:
           - "model/gen-ai/**"
           - "docs/gen-ai/**"
+          - "CHANGELOG.md"
       - repo: open-telemetry/community
         paths:
           - "projects/gen-ai/**"
@@ -286,6 +293,7 @@ mappings:
         paths:
           - "service/telemetry/**"
           - "internal/memorylimiter/**"
+          - "exporter/exporterhelper/**"
       - repo: open-telemetry/opentelemetry-collector-contrib
         paths:
           - "processor/memorylimiterprocessor/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.0] - 2026-03-11
 
 ### Added
-- Connectors reference (`references/connectors.md`): spanmetrics, servicegraph, routing, failover with stickiness requirements
+- Connectors reference (`references/connectors.md`): `span_metrics`, `service_graph`, routing, and failover with stickiness requirements
 - Kafka resiliency patterns, semconv v1.30+ guidance, config management, scaling guidance (Collector v0.147.0)
 - Upstream maintenance digest workflow (weekly automated scan of OTel issues, releases, and blog posts)
 - Cursor Marketplace plugin manifests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Add scaled `signal_to_metrics` correctness guidance and regression coverage for producer identity, backend resource mapping, temporality, and dashboard aggregation
+
 ### Changed
 - Replace upstream digest issue updates to overwrite issue body snapshots (instead of appending) while preserving idempotent no-op reruns on exact body matches
-- Add authoritative AI-agent eval coverage for the GenAI SemConv v1.41.0 tool-call span-naming requirement, alongside the skill/router guidance update
-- Bump published skill/package metadata versions for this update (`SKILL.md`, tile manifest, and marketplace plugin manifests)
+- Update GenAI guidance for the separate conventions repository, provider-versus-agent identity, histogram token usage, current content attributes, and execute-tool span naming
+- Migrate Collector examples and evaluations to canonical component IDs and raise the compatibility floor to v0.153.0
+- Document sparse exporter-helper failure metrics and expand upstream watcher coverage for GenAI conventions and exporter helpers
+- Bump aligned Tessl skill and tile metadata from `0.3.0` to `0.4.0`
 
 ## [1.3.0] - 2026-05-08
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ opentelemetry-skill/
 **AI Response** (leveraging the skill):
 - ✅ Asks about throughput to size replicas
 - ✅ Loads `references/architecture.md` and `references/sampling.md`
-- ✅ Generates Deployment with loadbalancing exporter (routing_key: traceID)
+- ✅ Generates Deployment with load_balancing exporter (routing_key: traceID)
 - ✅ Includes Headless Service for sticky sessions
 - ✅ Configures tail_sampling processor with error/latency policies
 - ✅ Warns about Beta stability level

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,8 +30,8 @@ tags:
   - ai-agent
 metadata:
   author: o11y.dev
-  version: 0.3.0
-  tessl_version: 0.3.0
+  version: 0.4.0
+  tessl_version: 0.4.0
   signals:
     - traces
     - metrics
@@ -105,7 +105,11 @@ metadata:
       - processor
       - exporter
       - connector
+      - span_metrics
       - spanmetrics
+      - service_graph
+      - signal_to_metrics
+      - signaltometrics
       - tail sampling
       - memory limiter
       - batch processor
@@ -158,9 +162,10 @@ When user requests match these patterns, include these points explicitly:
 
 - **Collector setup**: include `memory_limiter`; keep it first in each pipeline `processors` list; explain OOM-prevention rationale.
 - **Metric dimension request for `user_id`**: refuse; explain time-series explosion risk; suggest traces and bounded metric dimensions.
-- **Kubernetes tail sampling**: Gateway (Deployment) tier, `loadbalancing` with `routing_key: traceID`, Headless Service (`clusterIP: None`), error+10% policies, Beta stability caution.
+- **Kubernetes tail sampling**: Gateway (Deployment) tier, `load_balancing` with `routing_key: traceID`, Headless Service (`clusterIP: None`), error+10% policies, Beta stability caution.
 - **Claude Code telemetry**: include `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`, `~/.claude/settings.json` persistence; `OTEL_LOG_USER_PROMPTS`/`OTEL_LOG_TOOL_DETAILS` default to `false` — warn against enabling in shared/production environments without PII controls; avoid `session.id` as a metric dimension.
-- **AI agent tool-call tracing**: for agents using `gen_ai.*` traces, name execute-tool spans with the actual tool name (for example `bash` or `search_code`) and preserve `gen_ai.tool.name`; do not use a generic `execute_tool` span name.
+- **AI agent tool-call tracing**: for agents using current `gen_ai.*` conventions, set `gen_ai.operation.name: execute_tool`, preserve `gen_ai.tool.name`, and name the span `execute_tool {gen_ai.tool.name}` (for example, `execute_tool bash`).
+- **GenAI provider vs agent identity**: preserve `gen_ai.provider.name` for the model/provider (for example, `openai` or `gcp.gen_ai`); use `service.name` or a natively emitted agent attribute for the coding-agent identity rather than writing the agent name into the provider field.
 
 ## Existing Configuration Review Mode
 
@@ -169,13 +174,14 @@ When the user provides an existing collector config, Helm values file, or Kubern
 Check these interactions together:
 
 1. **Memory vs pod limit** — `limit_mib` must leave headroom for the Go runtime and buffers.
-2. **Stateful processing vs scaling** — `tail_sampling`, `spanmetrics`, and `servicegraph` need sticky routing above one replica.
+2. **Stateful processing vs scaling** — `tail_sampling`, `span_metrics`, and `service_graph` need sticky routing above one replica.
 3. **Durability vs outage tolerance** — disabled retries and no persistent queue mean data loss on backend failure.
 4. **Deployment mode vs exposure** — `hostPort` fits DaemonSet/node-local patterns, not scaled gateway Deployments.
 5. **Rollout settings** — review `replicaCount`, HPA `minReplicas`, PodDisruptionBudget, and rolling updates together.
 6. **OTTL/filter correctness** — keep attribute types consistent and prefer current semantic convention keys.
 7. **Metric temporality and state** — `deltatocumulative` / `cumulativetodelta` need source/backend/restart checks.
 8. **Queue storage backend** — `file_storage` needs local locking-safe storage; RWX, EFS, and NFS are unsafe defaults.
+9. **Generated metric identity** — for log/span-to-metric connectors, verify replica count, export mode, actual temporality, whether the emitted producer identity survives backend mapping, and the aggregation query shape together.
 
 ## Progressive Disclosure: Context Triggers
 
@@ -191,7 +197,7 @@ Load detailed reference documentation only when the user's request matches a tri
 | Monitor the collector, Health, Alerts, Self-monitoring, Collector metrics | [monitoring.md](references/monitoring.md) | otelcol_* metrics, dashboards, alert rules |
 | Lambda, Azure Functions, GCP Functions, Serverless, FaaS, Mobile, Browser | [platforms.md](references/platforms.md) | FaaS patterns, Lambda extension layer, client-side apps |
 | OTTL, Transform, Transformation, Modify, Filter attributes, Parse, Extract | [ottl.md](references/ottl.md) | OTTL syntax, context types, built-in functions, error handling |
-| Connector, spanmetrics, servicegraph, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness |
+| Connector, span_metrics, spanmetrics, service_graph, servicegraph, signal_to_metrics, signaltometrics, log-to-metric, span-to-metric, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness, generated-metric producer identity |
 | Claude Code, Codex, Gemini CLI, Copilot, AI agent, coding agent, MCP | [ai-agents.md](references/ai-agents.md) | Agent OTel support matrix, unified collector config, GenAI SemConv |
 | validate, dry-run, startup error, pipeline error, dropped data, queue full, recovery | [validation.md](references/validation.md) | Config validation commands, live checks, symptom→cause→fix recovery guidance |
 | playbook, production playbook, blog, 2025 blog, 2026 blog, real world | [playbooks.md](references/playbooks.md) | Production patterns from opentelemetry.io blogs |
@@ -281,7 +287,7 @@ For container dry-run commands, live pipeline checks, and symptom→cause→fix 
 ❌ Placing `memory_limiter` anywhere except first in the processor chain
 ❌ Using high-cardinality attributes (user_id, trace_id) as metric dimensions
 ❌ Exposing pprof (1777), zpages (55679) on `0.0.0.0` in production
-❌ Using `tail_sampling` without sticky session load balancing (loadbalancing exporter)
+❌ Using `tail_sampling` without sticky session load balancing (load_balancing exporter)
 ❌ Omitting `batch` processor (causes excessive network calls)
 ❌ Calling a config "fine" because it parses, without checking memory limits, sticky routing, exporter durability, and rollout settings together
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,10 +106,8 @@ metadata:
       - exporter
       - connector
       - span_metrics
-      - spanmetrics
       - service_graph
       - signal_to_metrics
-      - signaltometrics
       - tail sampling
       - memory limiter
       - batch processor
@@ -197,7 +195,7 @@ Load detailed reference documentation only when the user's request matches a tri
 | Monitor the collector, Health, Alerts, Self-monitoring, Collector metrics | [monitoring.md](references/monitoring.md) | otelcol_* metrics, dashboards, alert rules |
 | Lambda, Azure Functions, GCP Functions, Serverless, FaaS, Mobile, Browser | [platforms.md](references/platforms.md) | FaaS patterns, Lambda extension layer, client-side apps |
 | OTTL, Transform, Transformation, Modify, Filter attributes, Parse, Extract | [ottl.md](references/ottl.md) | OTTL syntax, context types, built-in functions, error handling |
-| Connector, span_metrics, spanmetrics, service_graph, servicegraph, signal_to_metrics, signaltometrics, log-to-metric, span-to-metric, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness, generated-metric producer identity |
+| Connector, span_metrics, service_graph, signal_to_metrics, log-to-metric, span-to-metric, routing connector, failover connector | [connectors.md](references/connectors.md) | R.E.D. metrics, service graph, routing, failover, stickiness, generated-metric producer identity |
 | Claude Code, Codex, Gemini CLI, Copilot, AI agent, coding agent, MCP | [ai-agents.md](references/ai-agents.md) | Agent OTel support matrix, unified collector config, GenAI SemConv |
 | validate, dry-run, startup error, pipeline error, dropped data, queue full, recovery | [validation.md](references/validation.md) | Config validation commands, live checks, symptom→cause→fix recovery guidance |
 | playbook, production playbook, blog, 2025 blog, 2026 blog, real world | [playbooks.md](references/playbooks.md) | Production patterns from opentelemetry.io blogs |

--- a/evals/core-scenarios.md
+++ b/evals/core-scenarios.md
@@ -57,7 +57,7 @@ Set up tail sampling in Kubernetes to sample 10% of traces but keep all error tr
 
 ### Expected Response (Key Points)
 - Recommends **Gateway deployment** pattern for tail sampling
-- Configures `loadbalancing` exporter with `routing_key: traceID`
+- Configures `load_balancing` exporter with `routing_key: traceID`
 - Sets up Headless Service for consistent routing
 - Warns about Beta stability level
 - Includes proper tail sampling policies (error rate + probabilistic)

--- a/evals/kubernetes-gateway/criteria.json
+++ b/evals/kubernetes-gateway/criteria.json
@@ -23,9 +23,9 @@
       "description": "The collector configuration includes file_storage extension and persistence queue settings to survive pod restarts. Must include volume mounts for persistence. Score zero if queues are in-memory only."
     },
     {
-      "name": "Implements loadbalancing exporter with trace ID routing",
+      "name": "Implements load_balancing exporter with trace ID routing",
       "max_score": 20,
-      "description": "For backend systems that require consistent trace routing, the configuration includes a loadbalancing exporter with routing_key: traceID. This enables tail sampling across replicas. Score zero if routing is not addressed."
+      "description": "For backend systems that require consistent trace routing, the configuration includes a load_balancing exporter with routing_key: traceID. This enables tail sampling across replicas. Score zero if routing is not addressed."
     },
     {
       "name": "Includes PodDisruptionBudget for high availability",

--- a/evals/kubernetes-gateway/task.md
+++ b/evals/kubernetes-gateway/task.md
@@ -1,6 +1,6 @@
 Deploy the OpenTelemetry Collector as a Gateway (Deployment) in Kubernetes to receive telemetry from distributed applications. The collector should:
 - Run as a Deployment (not DaemonSet) with configurable replicas
 - Use a load balancer service for distributing traffic
-- Implement a loadbalancing exporter to route traces by trace ID for tail sampling
+- Implement a load_balancing exporter to route traces by trace ID for tail sampling
 - Configure resource requests and limits appropriate for centralized processing
 - Use persistent queues for resilience against backend outages

--- a/evals/production-scenarios.md
+++ b/evals/production-scenarios.md
@@ -58,10 +58,10 @@ Scale an OpenTelemetry Collector deployment to handle 50,000 spans per second in
 **Difficulty**: Basic  
 
 ### Prompt
-Use the k8sattributes processor to enrich traces with Kubernetes metadata.
+Use the k8s_attributes processor to enrich traces with Kubernetes metadata.
 
 ### Expected Response (Key Points)
-- **Warns about Beta stability level** of k8sattributes processor
+- **Warns about Beta stability level** of k8s_attributes processor
 - Recommends pinning to specific collector version
 - Explains rollback strategy if issues occur
 - Mentions alternative approaches (resourcedetection processor)

--- a/evals/tail-sampling-setup/criteria.json
+++ b/evals/tail-sampling-setup/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Tests whether the skill causes the agent to recommend the Gateway deployment pattern with trace-ID-based load balancing when setting up tail sampling in Kubernetes. Without the skill, agents often suggest DaemonSet deployment which is architecturally incorrect for tail sampling. The skill should enforce the Gateway pattern with loadbalancing exporter and consistent trace routing.",
+  "context": "Tests whether the skill causes the agent to recommend the Gateway deployment pattern with trace-ID-based load balancing when setting up tail sampling in Kubernetes. Without the skill, agents often suggest DaemonSet deployment which is architecturally incorrect for tail sampling. The skill should enforce the Gateway pattern with load_balancing exporter and consistent trace routing.",
   "type": "weighted_checklist",
   "checklist": [
     {
@@ -8,9 +8,9 @@
       "description": "The response explicitly recommends a Gateway (Deployment) pattern rather than DaemonSet for the tail-sampling layer. If the response suggests DaemonSet for tail sampling, score zero — this is the core architectural mistake the skill prevents."
     },
     {
-      "name": "Configures loadbalancing exporter with routing_key: traceID",
+      "name": "Configures load_balancing exporter with routing_key: traceID",
       "max_score": 25,
-      "description": "The configuration includes a loadbalancing exporter with routing_key set to traceID. Without this, spans from the same trace would be routed to different collector instances, breaking tail sampling decisions. Missing the routing_key or using a different value scores zero."
+      "description": "The configuration includes a load_balancing exporter with routing_key set to traceID. Without this, spans from the same trace would be routed to different collector instances, breaking tail sampling decisions. Missing the routing_key or using a different value scores zero."
     },
     {
       "name": "Sets up Headless Service for consistent routing",

--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -261,7 +261,7 @@ A single OTel Collector instance can receive telemetry from all agents simultane
 ```yaml
 # otel-collector-ai-agents.yaml
 # Production-ready config for multi-agent AI coding observability
-# Tested with OTel Collector v0.151.0+
+# Tested with OTel Collector v0.153.0+
 
 extensions:
   health_check:
@@ -284,30 +284,12 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
 
-  # Normalize service.name across all agents
-  resource:
+  # Preserve each agent's service.name and add a common filter dimension
+  resource/enrich_agent_telemetry:
     attributes:
-      - key: service.name
-        action: upsert
-        from_attribute: service.name
-      # Tag all AI agent telemetry for easy filtering
       - key: telemetry.source.type
         value: ai-coding-agent
         action: insert
-
-  # Map custom claude_code.* prefixes to gen_ai.* where semantically equivalent
-  transform/normalize_agent_metrics:
-    metric_statements:
-      - context: datapoint
-        statements:
-          # Claude Code uses claude_code.* prefix — surface agent name for dashboards
-          - set(attributes["gen_ai.system"], "claude_code") where resource.attributes["service.name"] == "claude_code"
-          - set(attributes["gen_ai.system"], "gemini_cli") where resource.attributes["service.name"] == "gemini_cli"
-    log_statements:
-      - context: log
-        statements:
-          # Normalize agent identifier in log body for cross-agent queries
-          - set(attributes["gen_ai.system"], "claude_code") where resource.attributes["service.name"] == "claude_code"
 
   # Redact secrets from tool_parameters (reuse security.md pattern)
   transform/redact_secrets:
@@ -354,25 +336,27 @@ service:
     # Metrics pipeline — all agents
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, resource, transform/normalize_agent_metrics, batch]
+      processors: [memory_limiter, resource/enrich_agent_telemetry, batch]
       exporters: [prometheus]
 
     # Logs/Events pipeline — all agents
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, resource, transform/normalize_agent_metrics, transform/redact_secrets, batch]
+      processors: [memory_limiter, resource/enrich_agent_telemetry, transform/redact_secrets, batch]
       exporters: [otlphttp/loki]
 
     # Traces pipeline — Gemini CLI, Copilot only (others emit nothing here)
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, resource, batch]
+      processors: [memory_limiter, resource/enrich_agent_telemetry, batch]
       exporters: [otlp/tempo]
 ```
 
 **Protocol choice**: Prefer OTLP gRPC on `4317` for both receivers and exporters. Keep OTLP HTTP on `4318` available for agents like GitHub Copilot and for backends, proxies, or managed ingest endpoints where gRPC is unavailable.
 
-> **Processor ordering**: `memory_limiter` is always first. The `resource` processor runs before `transform` so enriched attributes are available for OTTL statements. `batch` is always last before exporters.
+> **Processor ordering**: `memory_limiter` is always first. Resource enrichment runs before transforms so added attributes are available to OTTL statements. `batch` is always last before exporters.
+
+> **Identity boundary**: Keep the agent identity in `service.name` (or a natively emitted agent attribute). `gen_ai.provider.name` identifies the GenAI provider, not the coding-agent product; never set it to values such as `claude_code`, `gemini_cli`, or `copilot` merely to unify dashboards.
 
 ---
 
@@ -388,40 +372,35 @@ service:
 | Claude Code | `claude_code.api.request.duration` | Histogram | `ms` | `model`, `status` |
 | Claude Code | `claude_code.tool.call.count` | Counter | `{call}` | `tool.name`, `status` |
 | Claude Code | `claude_code.cache.read.tokens` | Counter | `{token}` | `model` |
-| Gemini CLI | `gen_ai.client.token.usage` | Counter | `{token}` | `gen_ai.system`, `gen_ai.token.type`, `gen_ai.operation.name` |
-| Gemini CLI | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.response.finish_reason` |
-| GitHub Copilot | `gen_ai.client.token.usage` | Counter | `{token}` | `gen_ai.system`, `gen_ai.token.type` |
-| GitHub Copilot | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.system`, `gen_ai.operation.name` |
+| Gemini CLI | `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.provider.name`, `gen_ai.token.type`, `gen_ai.operation.name` |
+| Gemini CLI | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.provider.name`, `gen_ai.operation.name`, `error.type` |
+| GitHub Copilot | `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.provider.name`, `gen_ai.token.type`, `gen_ai.operation.name` |
+| GitHub Copilot | `gen_ai.client.operation.duration` | Histogram | `s` | `gen_ai.provider.name`, `gen_ai.operation.name`, `error.type` |
 | Codex CLI | `codex.tokens.used` | Counter | `{token}` | `model`, `direction` |
 | Codex CLI | `codex.request.latency` | Histogram | `ms` | `model`, `status` |
 
 > ⚠️ **Dashboard for evolving `gen_ai.token.type` values.** Do not assume GenAI token metrics are permanently limited to `input` and `output`. Newer semantic-convention work is adding finer-grained categories such as cache and reasoning tokens. Build charts and cost rollups so unknown token types are grouped, not discarded.
 
-**SemConv v1.40.0 review**: Preserve `gen_ai.agent.version`, `gen_ai.usage.cache_read.input_tokens`, and `gen_ai.usage.cache_creation.input_tokens` when agents emit them. These attributes help distinguish agent releases and cached-token behavior without collapsing everything back into a fixed `input`/`output` schema.
+**Current convention review**: GenAI conventions are now maintained in the separate [`open-telemetry/semantic-conventions-genai`](https://github.com/open-telemetry/semantic-conventions-genai) repository and are still marked Development. Preserve `gen_ai.provider.name`, `gen_ai.agent.version`, `gen_ai.usage.cache_read.input_tokens`, and `gen_ai.usage.cache_creation.input_tokens` when emitted. `gen_ai.system` is deprecated; do not synthesize it in Collector transforms.
 
 ### 4.2 Events / Logs
 
-| Agent | Event Name | Key Attributes | Correlation ID Field |
-|-------|------------|----------------|---------------------|
-| Claude Code | `gen_ai.user.message` | `gen_ai.system`, `session.id`, `prompt.id` | `prompt.id` |
-| Claude Code | `gen_ai.assistant.message` | `gen_ai.system`, `session.id`, `prompt.id`, `model` | `prompt.id` |
-| Claude Code | `gen_ai.tool.message` | `tool.name`, `session.id`, `prompt.id` | `prompt.id` |
-| Claude Code | `claude_code.api.request` | `model`, `prompt.id`, `input_tokens`, `output_tokens`, `cost_usd` | `prompt.id` |
-| Gemini CLI | `gen_ai.user.message` | `gen_ai.system`, `gen_ai.conversation.id` | `gen_ai.conversation.id` |
-| Gemini CLI | `gen_ai.assistant.message` | `gen_ai.system`, `gen_ai.conversation.id`, `gen_ai.response.model` | `gen_ai.conversation.id` |
-| GitHub Copilot | `gen_ai.user.message` | `gen_ai.system`, `gen_ai.thread.id` | `gen_ai.thread.id` |
-| GitHub Copilot | `gen_ai.choice` | `gen_ai.system`, `gen_ai.response.finish_reason` | `gen_ai.thread.id` |
-| Codex CLI | `codex.session.start` | `session.id`, `model`, `working_dir` | `session.id` |
-| Codex CLI | `codex.session.end` | `session.id`, `total_tokens`, `total_cost_usd` | `session.id` |
+Current GenAI conventions model captured content with opt-in structured attributes on spans or events rather than the deprecated per-message event names:
+
+| Content | Current attribute | Notes |
+|---------|-------------------|-------|
+| System instructions | `gen_ai.system_instructions` | Opt-in; may contain secrets or PII |
+| Input/chat history | `gen_ai.input.messages` | Opt-in; preserve message order and structured schema |
+| Model output | `gen_ai.output.messages` | Opt-in; one message per output choice/candidate |
+
+Do not generate `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.tool.message`, or `gen_ai.choice`; those event names are deprecated. Preserve vendor-native event names from Claude Code and Codex instead of relabeling them as standard GenAI events. Correlate with the native `prompt.id` or `session.id`, and use `gen_ai.conversation.id` when a GenAI-compatible source emits it.
 
 ### 4.3 Traces (where supported)
 
 | Agent | Span Name | Kind | Key Attributes | Child Spans |
 |-------|-----------|------|----------------|-------------|
-| Gemini CLI | `gen_ai.chat` | `CLIENT` | `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.request.model` | tool call spans |
-| Gemini CLI | tool name (for example `bash`) | `INTERNAL` | `gen_ai.tool.name`, `gen_ai.tool.call.id` | none |
-| GitHub Copilot | `gen_ai.chat` | `CLIENT` | `gen_ai.system`, `gen_ai.operation.name` | completion spans |
-| GitHub Copilot | `gen_ai.completion` | `INTERNAL` | `gen_ai.response.finish_reason`, `gen_ai.usage.input_tokens` | none |
+| GenAI inference | `{gen_ai.operation.name} {gen_ai.request.model}` | `CLIENT` (usually) | `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model` | tool call spans |
+| GenAI tool execution | `execute_tool {gen_ai.tool.name}` | `INTERNAL` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.call.id` | none |
 
 > **Note**: Claude Code emits **no traces**. Use `prompt.id` correlation across log events as a pseudo-trace (see [Known Gaps](#7-known-gaps--workarounds)).
 
@@ -444,12 +423,12 @@ Build these panels for a team-facing AI agent observability dashboard:
 
 1. **Token usage by agent/user/model over time**
    - Metric: `claude_code.tokens.input` + `claude_code.tokens.output` (Claude Code); `gen_ai.client.token.usage` (Gemini, Copilot)
-   - Dimensions: `model`, `gen_ai.system` (NOT `session.id` — high cardinality)
+   - Dimensions: `service.name` (agent), `gen_ai.provider.name`, and model (NOT `session.id` — high cardinality)
    - Chart type: Stacked bar, 1h buckets
 
 2. **Cost breakdown by agent and model**
    - Metric: `claude_code.cost.usd` (Claude Code); derived from token counts × model pricing for others
-   - Dimensions: `gen_ai.system`, `model`
+   - Dimensions: `service.name`, `gen_ai.provider.name`, and model
    - Chart type: Time series + running total stat panel
 
 3. **API request latency (p50/p95/p99)**
@@ -458,7 +437,7 @@ Build these panels for a team-facing AI agent observability dashboard:
 
 4. **Tool call success/failure rates**
    - Metric: `claude_code.tool.call.count` with `status` dimension
-   - Log query: filter `gen_ai.tool.message` events by `status`
+   - Trace query: filter spans where `gen_ai.operation.name = "execute_tool"`, grouped by `gen_ai.tool.name` and status; use the source's native event when traces are unavailable
    - Chart type: Success rate gauge + error rate alert
 
 5. **Active sessions / DAU/WAU/MAU**
@@ -481,7 +460,8 @@ Build these panels for a team-facing AI agent observability dashboard:
 | `session.id` | Unbounded | Use in **logs/events only**; keep `OTEL_METRICS_INCLUDE_SESSION_ID=false` |
 | `user.id` | Bounded by team size | Acceptable as metric dimension for small teams (<1000 users); use logs for larger orgs |
 | `model` | Low (~5–20 values) | Safe as metric dimension |
-| `gen_ai.system` | Low (~10 values) | Safe as metric dimension |
+| `gen_ai.provider.name` | Low (~10 values) | Safe provider dimension; do not use it for coding-agent identity |
+| `service.name` | Low for a controlled agent fleet | Preferred coding-agent dimension; enforce a bounded allowlist |
 | `tool.name` | Low–Medium | Acceptable as metric dimension if tools are bounded |
 
 > **Rule of 100**: Any attribute with >100 unique values should NOT be a metric dimension. Use logs or traces instead.
@@ -530,10 +510,10 @@ See `references/security.md` for comprehensive OTTL redaction patterns.
 prompt.id = "prompt_abc123"
 
 Log events sharing this prompt.id form a "trace":
-  → gen_ai.user.message   (prompt.id=prompt_abc123)
+  → <native user-prompt event>   (prompt.id=prompt_abc123)
   → claude_code.api.request (prompt.id=prompt_abc123)
-  → gen_ai.tool.message   (prompt.id=prompt_abc123, tool.name=bash)
-  → gen_ai.assistant.message (prompt.id=prompt_abc123)
+  → <native tool event>   (prompt.id=prompt_abc123, tool.name=bash)
+  → <native response event> (prompt.id=prompt_abc123)
 ```
 
 Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123"` to reconstruct a session's event timeline.
@@ -568,17 +548,17 @@ Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123
 
 ### 7.6 GenAI SemConv Coverage
 
-**⚠️ Breaking Change in Semantic Conventions v1.41.0**: The gen-ai conventions now require that tool call spans use the tool name for span naming. This affects agents using the `gen_ai.*` namespace for tool execution spans. Prefer span names like `bash`, `search_code`, or `read_file`, and still populate `gen_ai.tool.name`; do not emit a generic `execute_tool` span name.
+**Current execute-tool convention**: Set `gen_ai.operation.name` to `execute_tool`, populate `gen_ai.tool.name`, and name the span `execute_tool {gen_ai.tool.name}` (for example, `execute_tool bash`). A bare `execute_tool` span loses useful indexing context, while a span named only `bash` does not follow the current convention.
 
 | Agent | Uses `gen_ai.*` | Custom Prefix | Notes |
 |-------|----------------|---------------|-------|
-| Gemini CLI | ✅ Full | — | Follows `gen_ai.*` v1.40.0+ |
-| GitHub Copilot | ✅ Full | — | Follows `gen_ai.*` v1.40.0+ |
-| Claude Code | ❌ | `claude_code.*` | Uses OTTL `transform` to map (see §3) |
+| Gemini CLI | ✅ Full | — | Verify emitted fields against the agent version and Development GenAI conventions |
+| GitHub Copilot | ✅ Full | — | Verify emitted fields against the agent version and Development GenAI conventions |
+| Claude Code | ❌ | `claude_code.*` | Preserve the vendor schema and identify the agent with `service.name` |
 | Codex CLI | ❌ | `codex.*` | Custom event names, partial coverage |
 | Qwen Code | ⚠️ partial | `qwen-code.*` | v0.16.1 dual-emits selected `gen_ai.*` attributes (`gen_ai.request.model`, `gen_ai.usage.*`, `gen_ai.server.time_to_first_token`); private names remain authoritative |
 
-Use the `transform/normalize_agent_metrics` processor from [§3](#3-unified-collector-config-for-multi-agent-ingestion) to add `gen_ai.system` attributes to Claude Code and Codex telemetry for unified dashboard queries.
+For unified dashboards, group coding agents by `service.name` and providers by `gen_ai.provider.name`. Do not translate an agent product name into `gen_ai.provider.name`, and do not recreate deprecated `gen_ai.system` attributes.
 
 For dashboards and alerting, treat `gen_ai.token.type` as an **open set**. Keep normalizations additive (for example, mapping vendor-specific cache counters into a shared label) instead of rewriting unfamiliar values away.
 
@@ -590,7 +570,7 @@ There is also an active proposal for a dedicated **skill span** concept ([semant
 
 **Current guidance until conventions stabilize:**
 
-- Keep using stable `gen_ai.*`, core resource attributes, and vendor-specific fields that already exist.
+- Keep using the source's existing `gen_ai.*` fields, stable core resource attributes, and vendor-specific fields; treat the GenAI fields as Development rather than promising a stable schema.
 - If you must model agent identity, trust, or sandbox metadata today, place it under an **organization-controlled custom namespace** (for example, `company.agent.id`, `company.agent.trust_level`, `company.sandbox.runtime`) rather than betting on proposed upstream names.
 - Treat sandbox telemetry as a **deployment/runtime concern** first: make graceful flush, short-lived process export, and network-isolated delivery work before standardizing attribute names.
 - Do **not** use proposed agent or sandbox IDs as metric dimensions unless you have verified bounded cardinality; keep high-cardinality identifiers in traces/logs only.

--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -355,7 +355,7 @@ service:
 **Protocol choice**: Prefer OTLP gRPC on `4317` for both receivers and exporters. Keep OTLP HTTP on `4318` available for agents like GitHub Copilot and for backends, proxies, or managed ingest endpoints where gRPC is unavailable.
 
 > **Processor ordering**: `memory_limiter` is always first. Resource enrichment runs before transforms so added attributes are available to OTTL statements. `batch` is always last before exporters.
-
+>
 > **Identity boundary**: Keep the agent identity in `service.name` (or a natively emitted agent attribute). `gen_ai.provider.name` identifies the GenAI provider, not the coding-agent product; never set it to values such as `claude_code`, `gemini_cli`, or `copilot` merely to unify dashboards.
 
 ---

--- a/references/anti-patterns.md
+++ b/references/anti-patterns.md
@@ -32,9 +32,9 @@ Without batching, each span/metric/log is exported individually, producing thous
 
 ### Using `tail_sampling` without sticky session load balancing
 
-`tail_sampling` keeps per-trace state in memory. When multiple collector replicas compete for the same traffic without a `loadbalancing` exporter routing upstream, spans from the same trace are split across instances and sampling decisions diverge.
+`tail_sampling` keeps per-trace state in memory. When multiple collector replicas compete for the same traffic without a `load_balancing` exporter routing upstream, spans from the same trace are split across instances and sampling decisions diverge.
 
-**Fix:** Place a `loadbalancing` exporter (with `routing_key: traceID`) upstream of all `tail_sampling` replicas.
+**Fix:** Place a `load_balancing` exporter (with `routing_key: traceID`) upstream of all `tail_sampling` replicas.
 
 ---
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -318,7 +318,7 @@ spec:
 
 ❌ **High resource overhead** - Every pod pays the memory/CPU cost
 ❌ **Deployment complexity** - Must update all pods to change collector config
-❌ **No RBAC** - Cannot use k8sattributes processor (no cluster access)
+❌ **No RBAC** - Cannot use k8s_attributes processor (no cluster access)
 
 ✅ **Strong isolation** - Tenant A's collector never sees Tenant B's data
 ✅ **Fargate compatible** - No DaemonSet support in serverless
@@ -354,7 +354,7 @@ service:
       exporters: [otlp]  # Forward to gateway
     logs:
       receivers: [filelog]
-      processors: [memory_limiter, k8sattributes, batch]
+      processors: [memory_limiter, k8s_attributes, batch]
       exporters: [otlp]  # Forward to gateway
 ```
 
@@ -427,10 +427,10 @@ Span B (trace_id: 123) → Gateway Pod 1  ✅ Same pod!
 ### Solution: Load Balancing Exporter
 
 Use a **two-tier architecture**:
-1. **Pre-Gateway (Agents)**: Use loadbalancing exporter with traceID routing
+1. **Pre-Gateway (Agents)**: Use load_balancing exporter with traceID routing
 2. **Gateway**: Runs tail_sampling processor
 
-**Best Practice**: Configure the `loadbalancing` exporter with deterministic, low-cardinality string routing keys such as `traceID`, `tenant_id`, or `cluster`. Avoid non-string or high-cardinality volatile attributes (e.g., timestamps, session IDs) to preserve stickiness for stateful pipelines. Always normalize attributes to strings before routing to prevent shard churn and ensure consistent load distribution.
+**Best Practice**: Configure the `load_balancing` exporter with deterministic, low-cardinality string routing keys such as `traceID`, `tenant_id`, or `cluster`. Avoid non-string or high-cardinality volatile attributes (e.g., timestamps, session IDs) to preserve stickiness for stateful pipelines. Always normalize attributes to strings before routing to prevent shard churn and ensure consistent load distribution.
 
 ### Architecture
 
@@ -443,7 +443,7 @@ Agent → LoadBalancing Exporter (routing_key: traceID) → Gateway (Headless Se
 ```yaml
 # In the Agent or Pre-Gateway tier
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         endpoint: placeholder  # Will be replaced by resolver
@@ -478,7 +478,7 @@ spec:
 ### How It Works
 
 1. **Resolver discovers pods**: The k8s resolver queries the Headless Service and gets individual pod IPs (e.g., `10.0.1.5`, `10.0.1.6`, `10.0.1.7`)
-2. **Consistent hashing**: The loadbalancing exporter uses `traceID` as the routing key and applies consistent hashing to select the target pod
+2. **Consistent hashing**: The load_balancing exporter uses `traceID` as the routing key and applies consistent hashing to select the target pod
 3. **Sticky routing**: All spans with the same `traceID` hash to the same pod IP
 
 ### Critical Requirements
@@ -621,7 +621,7 @@ Is otelcol_exporter_queue_size / queue_capacity > 0.8?
 
 ❌ **Scaling without sampling** — at >50k RPS, you should evaluate tail sampling or head sampling before adding replicas
 
-❌ **Scaling stateful collectors without sticky routing** — more `tail_sampling` replicas without loadbalancing exporter splits traces across instances, breaking sampling correctness
+❌ **Scaling stateful collectors without sticky routing** — more `tail_sampling` replicas without load_balancing exporter splits traces across instances, breaking sampling correctness
 
 ❌ **Scaling to compensate for cardinality explosion** — unbounded attributes cause exponential storage growth regardless of replica count
 
@@ -667,13 +667,13 @@ For initial platform selection (which pattern matches your use case), see [setup
 ## Summary
 
 ✅ Use **DaemonSet** for logs and host metrics (always)
-✅ Use **Gateway** for tail sampling with loadbalancing exporter (sticky sessions)
+✅ Use **Gateway** for tail sampling with load_balancing exporter (sticky sessions)
 ✅ Use **Sidecar** only for serverless or strict isolation
 ✅ Use **Hybrid** for production (Agent → Gateway → Backend)
 ✅ Use **Target Allocator** for Prometheus scraping at scale
 ✅ Always configure **HPA** on memory utilization for gateways
-✅ Always use **Headless Service** with loadbalancing exporter
+✅ Always use **Headless Service** with load_balancing exporter
 ✅ Before scaling, check if the problem is **downstream** (backend saturation, not collector)
-✅ Use `otel/opentelemetry-collector-contrib:0.147.0` for current stable image
+✅ Pin a tested `otel/opentelemetry-collector-contrib` release at or above the compatibility floor; do not use `latest`
 
 **Deployment is not just about running a binary—it's about building a resilient, scalable observability pipeline.**

--- a/references/collector.md
+++ b/references/collector.md
@@ -60,11 +60,11 @@ Common receivers:
 Critical processors:
 - `memory_limiter`: **Must be first** - Prevents OOM
 - `batch`: **Should be near end** - Reduces network calls
-- `k8sattributes`: Enriches with K8s metadata
+- `k8s_attributes`: Enriches with K8s metadata
 - `transform`: Applies OTTL transformations
 - `filter`: Drops spans/metrics based on conditions
 - `tail_sampling`: Intelligent sampling decisions (stateful)
-  - **⚠️ Stateful Processor Note**: Stateful processors like `tail_sampling` and `spanmetrics` require sticky routing (routing all spans of a trace to the same collector instance). Pair with `loadbalancing` exporter using deterministic routing keys (e.g., `traceID`) to preserve stickiness.
+  - **⚠️ Stateful Processor Note**: Stateful processors like `tail_sampling` and `span_metrics` require sticky routing (routing all spans of a trace to the same collector instance). Pair with `load_balancing` exporter using deterministic routing keys (e.g., `traceID`) to preserve stickiness.
 - `attributes`: Adds/removes/hashes attributes
 - `resource`: Modifies resource attributes
 
@@ -76,7 +76,7 @@ Common exporters:
 - `otlp`: Exports to OTLP-compatible backends
 - `prometheus`: Exposes metrics for Prometheus scraping
 - `jaeger`: Exports to Jaeger (legacy)
-- `loadbalancing`: Routes to multiple backends with consistent hashing
+- `load_balancing`: Routes to multiple backends with consistent hashing
   - **⚠️ Routing Key Requirement**: The `routing_key` must be a stable, deterministic string (e.g., `traceID`, `tenant_id`, `cluster`). Convert non-string routing attributes to normalized strings before hashing to avoid shard churn and ensure even load distribution.
 - `logging`: Outputs to stdout (debug only)
 - `file`: Writes to disk (debug only)
@@ -86,12 +86,14 @@ Common exporters:
 **Connectors** bridge two pipelines by acting simultaneously as an exporter on the source pipeline and a receiver on the destination pipeline. They enable cross-pipeline signal routing and aggregation (e.g., generating metrics from traces) without external tools.
 
 Key connectors:
-- `spanmetrics`: Generates R.E.D. metrics (Rate, Errors, Duration) from trace spans — **Beta**
-- `servicegraph`: Builds service dependency graph metrics from traces — **Beta**
+- `span_metrics`: Generates R.E.D. metrics (Rate, Errors, Duration) from trace spans — **Beta**
+- `service_graph`: Builds service dependency graph metrics from traces — **Beta**
 - `routing`: Routes signals to different pipelines based on attribute values — **Alpha**
 - `failover`: Automatic failover between pipelines on errors — **Alpha**
 - `count`: Counts signals as metrics — **Alpha**
-- `signaltometrics`: Converts any signal to metrics via OTTL expressions — **Alpha**
+- `signal_to_metrics`: Converts any signal to metrics via OTTL expressions — **Alpha**
+
+> **Use canonical component IDs in new configuration.** Collector Contrib renamed the standalone IDs to `k8s_attributes` and `signal_to_metrics` in v0.147, `span_metrics` and `service_graph` in v0.151, and `load_balancing` in v0.153. The compact spellings remain deprecated aliases for compatibility, but examples in this skill use the canonical IDs.
 
 See [connectors.md](connectors.md) for full configuration examples and patterns.
 
@@ -112,7 +114,7 @@ service:
     
     logs:
       receivers: [otlp, filelog]
-      processors: [memory_limiter, k8sattributes, batch]
+      processors: [memory_limiter, k8s_attributes, batch]
       exporters: [otlp]
 ```
 
@@ -134,7 +136,7 @@ The `opentelemetry-collector` (core) contains **stable, vendor-neutral** compone
 ### Contrib Distribution
 
 The `opentelemetry-collector-contrib` contains **extended** components:
-- Advanced processors: `tail_sampling`, `transform`, `k8sattributes`
+- Advanced processors: `tail_sampling`, `transform`, `k8s_attributes`
 - Cloud-specific exporters: `awsxray`, `googlecloud`, `azuremonitor`
 - Specialized receivers: `filelog`, `kafkareceiver`, `sqlquery`
 
@@ -250,7 +252,7 @@ service:
 | **1** | `memory_limiter` | Prevents OOM | **Critical** | Must be first. If placed later, data has already consumed heap space before the limiter checks. Placing it first enables backpressure to receivers. |
 | **2** | `extensions` (auth) | Validates access | **High** | Reject unauthorized traffic immediately, before spending CPU on processing. |
 | **3** | `sampling` (head) | Reduces volume | **High** | If using probabilistic sampling, do it early. Dropping 90% of traces saves CPU on subsequent processors. |
-| **4** | `k8sattributes` | Enriches metadata | **Medium** | Adds context (Pod, Namespace, Node) needed for filtering and routing in later steps. Requires RBAC permissions. |
+| **4** | `k8s_attributes` | Enriches metadata | **Medium** | Adds context (Pod, Namespace, Node) needed for filtering and routing in later steps. Requires RBAC permissions. |
 | **5** | `transform` / `filter` | Modifies/drops data | **Medium** | Apply OTTL transformations to scrub, rename, or drop specific spans/metrics. |
 | **6** | `redaction` / `attributes` | Sanitizes PII | **Critical (Compliance)** | Must happen before batching or exporting to ensure sensitive data never leaves the collector. |
 | **7** | `batch` | Optimizes network | **High** | Compresses data into chunks. Must be near the end. If placed before filtering, the batcher processes data that is eventually discarded. |
@@ -264,7 +266,7 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 20
   
-  k8sattributes:
+  k8s_attributes:
     auth_type: "serviceAccount"
     extract:
       metadata:
@@ -290,7 +292,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, k8sattributes, filter, attributes, batch]
+      processors: [memory_limiter, k8s_attributes, filter, attributes, batch]
       exporters: [otlp]
 ```
 
@@ -332,7 +334,7 @@ Each component directory contains a README with configuration examples, stabilit
 
 > ⚠️ **Prometheus Remote Write — InstrumentationScope attributes not exported**: The `prometheusremotewriteexporter` does **not** include `otel.scope.name` / `otel.scope.version` as Prometheus labels by default ([#45266](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45266)). If downstream consumers need to distinguish metrics by instrumentation scope, use the native `otlpexporter` instead, or enrich the metric resource/data-point attributes before export using a `transform` processor.
 >
-> ⚠️ **Profiles signal is public Alpha**: OpenTelemetry Profiles entered public Alpha in Collector `v0.148.0+`. Use it for evaluation and early integration work, not critical production commitments yet. The current practical path is the `pprofreceiver` plus normal collector enrichment/transform processors (for example, `k8sattributes` and OTTL), and you should verify that your backend can ingest OTLP Profiles before standardizing on it.
+> ⚠️ **Profiles signal is public Alpha**: OpenTelemetry Profiles entered public Alpha in Collector `v0.148.0+`. Use it for evaluation and early integration work, not critical production commitments yet. The current practical path is the `pprofreceiver` plus normal collector enrichment/transform processors (for example, `k8s_attributes` and OTTL), and you should verify that your backend can ingest OTLP Profiles before standardizing on it.
 
 ### Example Configurations
 
@@ -344,10 +346,10 @@ Browse the [examples/ directory](https://github.com/open-telemetry/opentelemetry
 
 | Use Case | Example Type | Description |
 |----------|-------------|-------------|
-| **Gateway with tail sampling** | Gateway deployment | Stateful sampling across traces, requires consistent routing (e.g., via loadbalancing exporter) |
+| **Gateway with tail sampling** | Gateway deployment | Stateful sampling across traces, requires consistent routing (e.g., via load_balancing exporter) |
 | **Kubernetes node agents** | Agent/DaemonSet | Lightweight per-node collectors, hostmetrics, log collection |
 | **Log collection from files** | Filelog receiver | Parse and enrich logs from disk, multiline support |
-| **K8s metadata enrichment** | k8sattributes processor | Add pod/namespace/node attributes to telemetry |
+| **K8s metadata enrichment** | k8s_attributes processor | Add pod/namespace/node attributes to telemetry |
 | **Basic debugging** | Logging exporter | Output telemetry to stdout for troubleshooting |
 
 **Best Practice**: Pin to released tags (e.g., `v0.100.0+`) matching your collector version instead of using `main` branch. This ensures production stability and avoids unexpected breaking changes.
@@ -375,7 +377,7 @@ When reviewing an existing collector config or Helm values file, do more than sy
 |-------|-----------------|----------------|
 | **Processor chain** | `memory_limiter` first, `batch` near the end, every declared processor referenced by a pipeline | Correct ordering prevents OOMs and wasted work; unreferenced processors create dead config that misleads reviewers |
 | **Memory envelope** | `memory_limiter.limit_mib` / `limit_percentage` vs container memory limit | A limiter above the pod limit cannot protect the collector from cgroup OOM kills |
-| **Stateful processing** | `tail_sampling`, `spanmetrics`, `servicegraph` vs replica count/HPA and routing | Stateful processors break when traces/related spans are split across replicas |
+| **Stateful processing** | `tail_sampling`, `span_metrics`, `service_graph` vs replica count/HPA and routing | Stateful processors break when traces/related spans are split across replicas |
 | **Metric temporality/state** | `deltatocumulative`, `cumulativetodelta`, source temporality, backend expectation, and replica/restart behavior | Temporality conversion is stateful; restarts or non-sticky routing can create resets or incorrect cumulative series |
 | **Exporter durability** | `retry_on_failure`, `sending_queue`, `file_storage`, and stated outage tolerance | No retry + no queue means guaranteed loss during backend or network faults |
 | **Queue storage backend** | `file_storage` access mode, storage class, and whether the filesystem is local vs RWX/networked | Persistent queues need locking-safe local block storage; EFS/NFS/RWX can corrupt or stall queue state |
@@ -414,7 +416,7 @@ processors:
 
 #### 2. Tail sampling on scaled gateways without sticky routing
 
-If a Deployment can scale above one replica, a regular ClusterIP Service is **not enough** for `tail_sampling`. You need an upstream `loadbalancing` exporter with `routing_key: traceID` and a Headless Service for the gateway tier. Otherwise traces fragment across pods and sampling decisions are wrong.
+If a Deployment can scale above one replica, a regular ClusterIP Service is **not enough** for `tail_sampling`. You need an upstream `load_balancing` exporter with `routing_key: traceID` and a Headless Service for the gateway tier. Otherwise traces fragment across pods and sampling decisions are wrong.
 
 #### 3. Retry disabled and no durable queue
 
@@ -886,7 +888,7 @@ service:
   pipelines:
     traces:
       receivers: [kafka]
-      processors: [memory_limiter, k8sattributes, tail_sampling, batch]
+      processors: [memory_limiter, k8s_attributes, tail_sampling, batch]
       exporters: [otlp]
 ```
 
@@ -1322,7 +1324,7 @@ For stateful processors like `tail_sampling`, use load-balancing exporter to ens
 
 ```yaml
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         tls:
@@ -1339,7 +1341,7 @@ exporters:
 **Critical Rules**:
 1. **`routing_key: traceID`**: Must hash on trace ID (not random) to ensure all spans of a trace reach the same backend instance.
 2. **Headless Service** (Kubernetes): Use `clusterIP: None` for DNS resolution to all backend pods.
-3. **Pair with stateful processors**: Use this exporter when you have `tail_sampling`, `spanmetrics`, or `servicegraph` on the backend tier.
+3. **Pair with stateful processors**: Use this exporter when you have `tail_sampling`, `span_metrics`, or `service_graph` on the backend tier.
 
 ### Load-Balancing Exporter: Multi-Backend with Failover
 
@@ -1347,7 +1349,7 @@ For resilience without statefulness:
 
 ```yaml
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         tls:

--- a/references/compatibility.md
+++ b/references/compatibility.md
@@ -4,8 +4,9 @@ Use this document for version-sensitive guidance that changes more frequently th
 
 ## Baseline version floors
 
-- **OpenTelemetry Collector**: v0.151.0+
-- **Semantic Conventions**: v1.40.0+
+- **OpenTelemetry Collector**: v0.153.0+ (the first release that supports every canonical component ID used by this skill, including `load_balancing`)
+- **Core Semantic Conventions**: v1.40.0+
+- **GenAI Semantic Conventions**: follow the separate `open-telemetry/semantic-conventions-genai` repository; the signal definitions are Development and do not currently have a stable release floor
 - **Kubernetes**: v1.24+ for native sidecar support
 - **Go SDK**: v1.24.0+
 - **Python SDK**: v1.41.0+
@@ -21,5 +22,6 @@ Use this document for version-sensitive guidance that changes more frequently th
 ## Maintenance guidance
 
 - Treat these version floors as fast-moving compatibility notes rather than hard-coded architectural rules.
+- Pin GenAI dashboards and transforms to the fields actually emitted by the agent/instrumentation version; do not infer current GenAI behavior from the core Semantic Conventions version alone.
 - Pin collector components to released versions and verify stability levels before using non-stable features in production.
 - Re-check upstream release notes whenever updating examples that depend on AI agent telemetry support or evolving semantic conventions.

--- a/references/connectors.md
+++ b/references/connectors.md
@@ -45,10 +45,10 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [spanmetrics]          # connector as exporter
+      exporters: [span_metrics]          # connector as exporter
 
     metrics:
-      receivers: [spanmetrics]          # same connector as receiver
+      receivers: [span_metrics]          # same connector as receiver
       processors: [memory_limiter, batch]
       exporters: [otlp]
 ```
@@ -56,6 +56,8 @@ service:
 ---
 
 ## Production-Relevant Connectors
+
+Configuration examples use the canonical component IDs `span_metrics`, `service_graph`, and `signal_to_metrics`. Collector Contrib still accepts the older compact IDs as deprecated aliases. Package/component names such as `spanmetricsconnector` and `signaltometricsconnector` are unchanged.
 
 | Connector | Purpose | Source Signal | Output Signal | Stability |
 |-----------|---------|---------------|---------------|-----------|
@@ -81,7 +83,7 @@ Generates **R.E.D. metrics** (Rate, Errors, Duration) from trace spans without r
 
 ```yaml
 connectors:
-  spanmetrics:
+  span_metrics:
     histogram:
       explicit:
         buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]  # milliseconds
@@ -99,10 +101,10 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlp, spanmetrics]    # forward traces AND generate metrics
+      exporters: [otlp, span_metrics]    # forward traces AND generate metrics
 
     metrics:
-      receivers: [otlp, spanmetrics]    # receive both OTLP metrics and generated metrics
+      receivers: [otlp, span_metrics]    # receive both OTLP metrics and generated metrics
       processors: [memory_limiter, batch]
       exporters: [otlp]
 ```
@@ -112,9 +114,9 @@ service:
 `spanmetricsconnector` is **stateful** — it aggregates metrics in-memory across spans. In a multi-replica gateway deployment, all spans for the same service or trace must route to the **same collector instance**.
 
 ```yaml
-# Agent-tier: use loadbalancing exporter to stick spans to a gateway replica
+# Agent-tier: use load_balancing exporter to stick spans to a gateway replica
 exporters:
-  loadbalancing:
+  load_balancing:
     routing_key: traceID              # deterministic routing to gateway
     protocol:
       otlp:
@@ -146,7 +148,7 @@ Generates **service dependency graph metrics** showing request rates and error r
 
 ```yaml
 connectors:
-  servicegraph:
+  service_graph:
     latency_histogram_buckets: [1, 2, 6, 10, 100, 250]  # milliseconds
     dimensions:
       - http.request.method
@@ -159,17 +161,17 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlp, servicegraph]   # forward traces AND generate graph metrics
+      exporters: [otlp, service_graph]   # forward traces AND generate graph metrics
 
     metrics:
-      receivers: [otlp, servicegraph]
+      receivers: [otlp, service_graph]
       processors: [memory_limiter, batch]
       exporters: [otlp]
 ```
 
 ### ⚠️ Stickiness Requirement
 
-Like `spanmetricsconnector`, the `servicegraphconnector` is **stateful**. It must see both the client span and the server span for a given request to compute the edge. Use the `loadbalancing` exporter with `routing_key: traceID` to route all spans of a trace to the same gateway replica.
+Like `spanmetricsconnector`, the `servicegraphconnector` is **stateful**. It must see both the client span and the server span for a given request to compute the edge. Use the `load_balancing` exporter with `routing_key: traceID` to route all spans of a trace to the same gateway replica.
 
 ---
 
@@ -311,7 +313,7 @@ Converts any signal type (traces, logs, or metrics) into metrics using OTTL expr
 
 ```yaml
 connectors:
-  signaltometrics:
+  signal_to_metrics:
     spans:
       - name: http.server.request.duration
         description: HTTP server request duration from spans
@@ -337,13 +339,25 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlp, signaltometrics]    # connector as exporter
+      exporters: [otlp, signal_to_metrics]    # connector as exporter
 
     metrics:
-      receivers: [otlp, signaltometrics]    # connector as receiver
+      receivers: [otlp, signal_to_metrics]    # connector as receiver
       processors: [memory_limiter, batch]
       exporters: [otlp]
 ```
+
+### ⚠️ Generated Metrics in Scaled Collectors
+
+Each collector replica is a separate metric producer. Current `signal_to_metrics` releases emit sums, histograms, and exponential histograms with **delta temporality** and automatically add the resource attribute `signal_to_metrics.service.instance.id`, using the Collector's instance identity. That built-in attribute protects the generated streams only when the exporter and backend preserve or map it into the stored metric identity.
+
+Review the backend's stored series, not only the Collector config. If `signal_to_metrics.service.instance.id` is dropped during resource-to-label translation, multiple replicas can collapse into the same histogram label set; a downstream delta-to-cumulative conversion can then create competing cumulative streams, resets, spikes, or incorrect totals. Preserve or map the built-in attribute. For an older/custom connector or another log/span-to-metric path that emits no producer identity, add a unique identity that is stable for the replica's lifetime. Use `service.instance.id` only when the generated metric resource intentionally represents the Collector; otherwise use a scoped attribute such as `collector_instance`.
+
+Apply any fallback identity only to the connector-generated metric stream. If its destination pipeline also carries application metrics, split the generated metrics into a dedicated pipeline before enrichment rather than adding pod labels to every metric.
+
+Dashboards and alerts must aggregate the producer identity away, for example with `sum by (<business dimensions>) (...)`. Retain histogram-specific grouping such as `le` when querying classic histogram buckets. A histogram's `_count` already supplies the event count (and event rate after `rate()`), so do not add a separate counter solely for that purpose.
+
+Prometheus scraping usually adds target identity such as the `instance` label on the scrape path. Direct OTLP/backend export does not guarantee that resource identity becomes part of the backend's stored series, so verify it explicitly when reviewing replica count, effective temporality, and query aggregation.
 
 ---
 
@@ -353,18 +367,18 @@ service:
 
 ```yaml
 connectors:
-  spanmetrics: {}
-  servicegraph: {}
+  span_metrics: {}
+  service_graph: {}
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, k8sattributes, batch]
-      exporters: [otlp, spanmetrics, servicegraph]
+      processors: [memory_limiter, k8s_attributes, batch]
+      exporters: [otlp, span_metrics, service_graph]
 
     metrics:
-      receivers: [otlp, spanmetrics, servicegraph]
+      receivers: [otlp, span_metrics, service_graph]
       processors: [memory_limiter, batch]
       exporters: [otlp]
 ```
@@ -435,8 +449,8 @@ All connectors are in the [opentelemetry-collector-contrib](https://github.com/o
 ✅ Use **servicegraphconnector** to build service dependency maps from trace data
 ✅ Use **routingconnector** for attribute-based multi-tenant or multi-environment pipeline routing
 ✅ Use **failoverconnector** for automatic cross-region or cross-backend failover
-✅ Always pair **stateful connectors** (spanmetrics, servicegraph) with the `loadbalancing` exporter and `routing_key: traceID`
+✅ Always pair **stateful connectors** (span_metrics, service_graph) with the `load_balancing` exporter and `routing_key: traceID`
 ✅ Check **stability levels** — only `spanmetricsconnector` and `servicegraphconnector` are Beta; others are Alpha
-⚠️ Avoid **high-cardinality dimensions** in spanmetrics/servicegraph to prevent time series explosion
+⚠️ Avoid **high-cardinality dimensions** in span_metrics/service_graph to prevent time series explosion
 
 **Connectors are the bridge between pipeline stages — use them to turn trace data into metrics and to route signals across pipelines without external tooling.**

--- a/references/instrumentation.md
+++ b/references/instrumentation.md
@@ -464,7 +464,7 @@ log-based events back into span views, prefer that over adding new span events.
 
 ### Kubernetes Semantic Conventions (`release_candidate` in v1.30+)
 
-The `k8s.*` attribute namespace has been promoted to **`release_candidate`** stability ([semantic-conventions#3380](https://github.com/open-telemetry/semantic-conventions/issues/3380)), meaning attribute names are stable and backend support is expected. This makes it safe to rely on these names in production instrumentation and collector enrichment (via `k8sattributes` processor).
+The `k8s.*` attribute namespace has been promoted to **`release_candidate`** stability ([semantic-conventions#3380](https://github.com/open-telemetry/semantic-conventions/issues/3380)), meaning attribute names are stable and backend support is expected. This makes it safe to rely on these names in production instrumentation and collector enrichment (via `k8s_attributes` processor).
 
 **Cardinality guidance for k8s attributes as metric dimensions**:
 
@@ -481,10 +481,10 @@ The `k8s.*` attribute namespace has been promoted to **`release_candidate`** sta
 
 > ⚠️ **Node-level cardinality**: In clusters with >100 nodes, `k8s.node.name` exceeds the Rule of 100. Avoid using it as a metric dimension in large clusters; use it in traces/logs for per-node debugging instead.
 
-**Recommended attributes for k8s-enriched metrics** (via `k8sattributes` processor):
+**Recommended attributes for k8s-enriched metrics** (via `k8s_attributes` processor):
 ```yaml
 processors:
-  k8sattributes:
+  k8s_attributes:
     auth_type: "serviceAccount"
     extract:
       metadata:

--- a/references/monitoring.md
+++ b/references/monitoring.md
@@ -309,16 +309,18 @@ otelcol_exporter_queue_capacity
 
 **Metrics**:
 ```promql
-# Export latency
+# Failed metric points sent to the backend
 otelcol_exporter_send_failed_metric_points
 
-# Retry count
+# Spans rejected before enqueue
 otelcol_exporter_enqueue_failed_spans
 ```
 
+> **Sparse zero-value series in recent Collectors:** In Collector v0.156, exporter-helper failure counters may not be recorded until a failure occurs. Their absence can therefore mean "zero failures so far" rather than a broken scrape. Do not use `absent(otelcol_exporter_send_failed_*)` as a collector-liveness or data-loss alert. Pair failure-rate alerts with an independent scrape `up`, health-check, or heartbeat signal.
+
 **Query** (export failure rate):
 ```promql
-rate(otelcol_exporter_send_failed_spans[1m])
+sum(rate(otelcol_exporter_send_failed_spans[5m]))
 ```
 
 **Alert threshold**: > 0 (any failures)
@@ -710,7 +712,7 @@ otelcol_exporter_queue_size
 **Symptoms**: Traces missing spans, incorrect sampling decisions
 
 **Check**:
-- Verify loadbalancing exporter is using `routing_key: traceID`
+- Verify load_balancing exporter is using `routing_key: traceID`
 - Check Headless Service is returning pod IPs, not VIP
 - Verify `decision_wait` is long enough for trace completion
 

--- a/references/sampling.md
+++ b/references/sampling.md
@@ -350,14 +350,14 @@ Decision Time:
 Use a **two-tier architecture**:
 
 ```
-Agent (with loadbalancing exporter) → Gateway (with tail_sampling processor)
+Agent (with load_balancing exporter) → Gateway (with tail_sampling processor)
 ```
 
 **Agent Configuration**:
 
 ```yaml
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         endpoint: placeholder
@@ -375,7 +375,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 ```
 
 **Gateway Configuration**:
@@ -553,8 +553,8 @@ The OpenTelemetry specification has an active proposal — [open-telemetry/opent
 ✅ Use **head sampling** (ParentBasedTraceIdRatio) for simple, distributed sampling
 ✅ Use **tail sampling** for intelligent, policy-based sampling (errors, latency)
 ✅ Always use **ParentBased** to ensure trace completeness across services
-✅ Use **loadbalancing exporter with routing_key: traceID** for tail sampling stickiness
-✅ Deploy **two-tier architecture** (Agent with loadbalancing → Gateway with tail_sampling)
+✅ Use **load_balancing exporter with routing_key: traceID** for tail sampling stickiness
+✅ Deploy **two-tier architecture** (Agent with load_balancing → Gateway with tail_sampling)
 ✅ Size tail_sampling memory: `num_traces = RPS × decision_wait × spans_per_trace`
 ✅ Monitor `otelcol_processor_tail_sampling_policy_decision` metrics
 

--- a/references/security.md
+++ b/references/security.md
@@ -511,7 +511,7 @@ go tool pprof http://localhost:1777/debug/pprof/heap
 
 ### Kubernetes ServiceAccount
 
-The collector requires specific RBAC permissions for k8sattributes processor:
+The collector requires specific RBAC permissions for k8s_attributes processor:
 
 ```yaml
 apiVersion: v1

--- a/references/setup-kubernetes.md
+++ b/references/setup-kubernetes.md
@@ -241,7 +241,7 @@ spec:
 ```
 
 **Key gotchas:**
-- **TraceID routing for tail sampling**: Kubernetes `sessionAffinity: ClientIP` is still a valid option for ordinary gateway scale-out and for topologies where all spans for a trace arrive from the same client source. It is not trace-aware, so traces that include spans from multiple pods or services can still be split across gateway replicas. For tail sampling in multi-source traces, send traces through upstream agents that use the `loadbalancing` exporter with `routing_key: traceID` and resolve this headless service.
+- **TraceID routing for tail sampling**: Kubernetes `sessionAffinity: ClientIP` is still a valid option for ordinary gateway scale-out and for topologies where all spans for a trace arrive from the same client source. It is not trace-aware, so traces that include spans from multiple pods or services can still be split across gateway replicas. For tail sampling in multi-source traces, send traces through upstream agents that use the `load_balancing` exporter with `routing_key: traceID` and resolve this headless service.
 - **Replica count strategy**: Use odd numbers (3, 5, 7) for better distribution; avoid 2 or 4
 - **Memory limiter**: Set aggressive `memory_limiter` in config to prevent OOM kills during traffic spikes
 - **Tracestate headers**: Tail sampling decisions rely on consistent routing; if sticky routing fails, sampling is non-deterministic
@@ -273,7 +273,7 @@ Agent exporter for tail-sampling stickiness:
 
 ```yaml
 exporters:
-  loadbalancing:
+  load_balancing:
     routing_key: traceID
     protocol:
       otlp:

--- a/references/validation.md
+++ b/references/validation.md
@@ -36,4 +36,4 @@ curl -s http://localhost:8888/metrics | grep -E "otelcol_processor_dropped|otelc
 | `exporter queue is full` | Backend unreachable or slow | Verify endpoint reachability; increase `queue_size`; check `retry_on_failure` settings |
 | `pipeline drops data` on restart | No persistent queue | Add `file_storage` extension and set `storage: file_storage/queue` in exporter sending_queue |
 | OTTL statement silently skipped | Type mismatch or nil value | Add `error_mode: ignore`; guard with `where attributes["key"] != nil`; use `Int()` / `String()` converters |
-| Tail sampling misses spans | Spans split across collector instances | Use `loadbalancing` exporter with `routing_key: traceID` upstream |
+| Tail sampling misses spans | Spans split across collector instances | Use `load_balancing` exporter with `routing_key: traceID` upstream |

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -105,21 +105,21 @@ I need to implement tail sampling in my OpenTelemetry Collector gateway to reduc
 
 ### Expected Baseline Behavior (WITHOUT skill)
 - Configures tail_sampling processor
-- **Likely SKIPS:** loadbalancing exporter with traceID routing
+- **Likely SKIPS:** load_balancing exporter with traceID routing
 - **Likely MISSES:** Warning that tail sampling requires all spans of a trace on same collector
 - **Rationalization:** "Here's the tail sampling config"
 
 ### Target Behavior (WITH skill)
 - Asks about deployment architecture (how many collector instances)
 - Explains requirement for sticky sessions (traceID routing)
-- Provides loadbalancing exporter configuration with `routing_key: traceID`
+- Provides load_balancing exporter configuration with `routing_key: traceID`
 - Includes Headless Service YAML for Kubernetes
 - Warns about tail_sampling stability level (Beta)
 - References sampling.md and architecture.md
 
 ### Success Criteria
 - [ ] Agent mentions load balancing requirement
-- [ ] Agent provides loadbalancing exporter config
+- [ ] Agent provides load_balancing exporter config
 - [ ] Agent explains why traceID routing is mandatory
 - [ ] Agent warns about stability level
 - [ ] Agent doesn't provide tail sampling without addressing load balancing
@@ -403,7 +403,7 @@ exporters:
 
 ### Target Behavior (WITH skill)
 - Flags that `memory_limiter.limit_mib` exceeds pod memory limit and should leave runtime headroom
-- Flags `tail_sampling` on a Deployment that can scale above one replica without sticky routing/loadbalancing exporter
+- Flags `tail_sampling` on a Deployment that can scale above one replica without sticky routing/load_balancing exporter
 - Flags `hostPort` as suspicious for a scaled gateway Deployment
 - Flags `retry_on_failure: false` with no durable queue as an explicit data-loss trade-off
 - Flags rollout inconsistency across `replicaCount`, HPA, and PodDisruptionBudget

--- a/tests/compliance-verification.md
+++ b/tests/compliance-verification.md
@@ -122,21 +122,21 @@ Look for agent:
 ### Expected Improvements
 
 **Baseline → Compliance Changes:**
-- Agent NOW requires loadbalancing exporter for tail sampling
+- Agent NOW requires load_balancing exporter for tail sampling
 - Agent explains sticky session requirement
 - Agent provides traceID routing configuration
 
 ### Success Criteria Verification
 
 - [ ] Agent mentions load balancing requirement
-- [ ] Agent provides loadbalancing exporter config
+- [ ] Agent provides load_balancing exporter config
 - [ ] Agent explains traceID routing requirement
 - [ ] Agent warns about stability level
 
 ### Evidence Checklist
 
 Look for agent:
-- Mentioning "loadbalancing exporter"
+- Mentioning "load_balancing exporter"
 - Explaining "routing_key: traceID"
 - Warning "all spans of a trace must reach same collector"
 - Referencing sampling.md and architecture.md
@@ -338,6 +338,36 @@ Look for agent:
 - Explaining that `deltatocumulative` keeps per-timeseries state and can reset on restart/scale events
 - Saying `ReadWriteMany` + `efs` is unsafe for bbolt-backed `file_storage`
 - Identifying `groupbyattrs/keep_stable_labels` as unused
+
+---
+
+## Focused Regression Check: Scaled `signal_to_metrics` Histogram Direct Export
+
+### Test Prompt
+
+```text
+Review this design for metric correctness. A logs collector runs with three replicas. Each replica uses the current signal_to_metrics connector to generate a log.processing.duration histogram with an outcome attribute and exports it directly over OTLP to a backend. In the backend, the stored histogram is cumulative and has the same metric/outcome label set from every replica; inspection shows that signal_to_metrics.service.instance.id is not retained as series identity. The destination metrics pipeline also carries application metrics. The dashboard needs latency and event rate. Is this safe, and what should change?
+```
+
+### Expected Improvements
+
+- Agent explains that current `signal_to_metrics` emits delta histograms and automatically adds `signal_to_metrics.service.instance.id`.
+- Agent identifies the backend's loss of that resource identity, followed by a cumulative representation, as creating competing metric streams with the same stored label set.
+- Agent first recommends preserving or mapping the built-in producer identity. For an older/custom path that emits no identity, it recommends `service.instance.id` only when the metric resource represents the Collector, or a scoped `collector_instance` fallback otherwise.
+- Agent scopes the identity to a dedicated connector-generated metrics pipeline rather than adding pod labels to all metrics.
+- Agent requires dashboards to aggregate the producer identity away with `sum by (...)`, retaining histogram bucket dimensions where applicable.
+- Agent contrasts direct export with Prometheus scraping, where the scrape path usually adds an `instance` identity.
+- Agent uses the histogram `_count` for event rate instead of recommending a duplicate counter.
+
+### Success Criteria Verification
+
+- [ ] Agent checks replica count, direct export mode, connector delta temporality, backend cumulative conversion, producer identity, and query aggregation together.
+- [ ] Agent flags the dropped per-replica identity before approving the design.
+- [ ] Agent recognizes the current connector's built-in `signal_to_metrics.service.instance.id` instead of blindly adding a duplicate identity.
+- [ ] Agent limits producer enrichment to the generated metric stream.
+- [ ] Agent recommends aggregation across producers in dashboards and alerts.
+- [ ] Agent does not recommend adding pod labels to all application metrics.
+- [ ] Agent does not recommend a separate event counter when the histogram `_count` is sufficient.
 
 ---
 

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "o11y-dev/opentelemetry-skill",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "summary": "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation across Kubernetes, ECS, serverless, and standalone deployments. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot).",
   "docs": "docs/index.md",


### PR DESCRIPTION
## Summary

- teach scaled `signal_to_metrics` producer identity and backend mapping correctness
- add focused regression coverage without broad pod-label enrichment or duplicate counters
- refresh GenAI conventions, Collector canonical component IDs, and sparse exporter failure guidance from open-issue research
- bump aligned Tessl skill and tile metadata from `0.3.0` to `0.4.0`

## Validation

- SKILL.md frontmatter and version alignment
- `.github/upstream-map.yaml` parsing
- internal reference links
- `git diff --check`