### PR TITLE
Refresh upstream agent and instrumentation guidance

### DIFF
--- a/.github/scripts/repos.json
+++ b/.github/scripts/repos.json
@@ -40,6 +40,7 @@
       "open-telemetry/opentelemetry-js-contrib",
       "open-telemetry/opentelemetry-dotnet-contrib",
       "open-telemetry/opentelemetry-go-instrumentation",
+      "open-telemetry/opentelemetry-go-compile-instrumentation",
       "open-telemetry/opentelemetry-lambda",
       "open-telemetry/opentelemetry-rust",
       "open-telemetry/opentelemetry-cpp",

--- a/.github/upstream-map.yaml
+++ b/.github/upstream-map.yaml
@@ -241,6 +241,13 @@ mappings:
         paths:
           - "internal/pkg/instrumentation/**"
           - "CHANGELOG.md"
+      - repo: open-telemetry/opentelemetry-go-compile-instrumentation
+        paths:
+          - "README.md"
+          - "CHANGELOG.md"
+          - "docs/**"
+          - "rules/**"
+          - "instrumentation/**"
       - repo: open-telemetry/opentelemetry-rust
         paths:
           - "CHANGELOG.md"

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Run Tessl skill review
         uses: tesslio/skill-review-and-optimize@90e919d50ecb2dd11e07d69ef1440e7b2716189b
         with:
-          optimize: true
+          optimize: false
           tessl-token: ${{ secrets.TESSL_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Replace upstream digest issue updates to overwrite issue body snapshots (instead of appending) while preserving idempotent no-op reruns on exact body matches
 - Update GenAI guidance for the separate conventions repository, provider-versus-agent identity, histogram token usage, current content attributes, and execute-tool span naming
+- Refresh AI-agent telemetry guidance from current upstream documentation: Claude Code beta traces, Gemini prompt/traces controls, Copilot namespace migration, and Codex mode-specific verification
+- Add current OpenTelemetry blog playbooks for Go compile-time instrumentation v1, GenAI observability, and OTel blueprints
+- Update instrumentation guidance from deprecated `gen_ai.system` to `gen_ai.provider.name` and document stable Go compile-time instrumentation as an alternative to eBPF and manual SDK work
 - Migrate Collector examples and evaluations to canonical component IDs and raise the compatibility floor to v0.153.0
 - Document sparse exporter-helper failure metrics and expand upstream watcher coverage for GenAI conventions and exporter helpers
 - Bump aligned Tessl skill and tile metadata from `0.3.0` to `0.4.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update instrumentation guidance from deprecated `gen_ai.system` to `gen_ai.provider.name` and document stable Go compile-time instrumentation as an alternative to eBPF and manual SDK work
 - Migrate Collector examples and evaluations to canonical component IDs and raise the compatibility floor to v0.153.0
 - Document sparse exporter-helper failure metrics and expand upstream watcher coverage for GenAI conventions and exporter helpers
-- Bump aligned Tessl skill and tile metadata from `0.3.0` to `0.4.0`
+- Bump aligned Tessl skill and tile metadata from `0.4.0` to `0.5.0`
 
 ## [1.3.0] - 2026-05-08
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -161,8 +161,8 @@ When user requests match these patterns, include these points explicitly:
 - **Collector setup**: include `memory_limiter`; keep it first in each pipeline `processors` list; explain OOM-prevention rationale.
 - **Metric dimension request for `user_id`**: refuse; explain time-series explosion risk; suggest traces and bounded metric dimensions.
 - **Kubernetes tail sampling**: Gateway (Deployment) tier, `load_balancing` with `routing_key: traceID`, Headless Service (`clusterIP: None`), error+10% policies, Beta stability caution.
-- **Claude Code telemetry**: include `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`, `~/.claude/settings.json` persistence; `OTEL_LOG_USER_PROMPTS`/`OTEL_LOG_TOOL_DETAILS` default to `false` — warn against enabling in shared/production environments without PII controls; avoid `session.id` as a metric dimension.
-- **AI agent tool-call tracing**: for agents using current `gen_ai.*` conventions, set `gen_ai.operation.name: execute_tool`, preserve `gen_ai.tool.name`, and name the span `execute_tool {gen_ai.tool.name}` (for example, `execute_tool bash`).
+- **Claude Code telemetry**: include `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`, and managed-settings persistence; traces are beta, while metrics and logs/events remain the broadly documented signals. Keep prompt/tool-content capture disabled unless PII controls are explicit, and avoid `session.id` as a metric dimension.
+- **AI agent tool-call tracing**: for agents using current `gen_ai.*` conventions, set `gen_ai.operation.name: execute_tool`, preserve `gen_ai.tool.name`, and use the stable span name `execute_tool`; keep the actual tool name in the attribute.
 - **GenAI provider vs agent identity**: preserve `gen_ai.provider.name` for the model/provider (for example, `openai` or `gcp.gen_ai`); use `service.name` or a natively emitted agent attribute for the coding-agent identity rather than writing the agent name into the provider field.
 
 ## Existing Configuration Review Mode

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,8 +30,8 @@ tags:
   - ai-agent
 metadata:
   author: o11y.dev
-  version: 0.4.0
-  tessl_version: 0.4.0
+  version: 0.5.0
+  tessl_version: 0.5.0
   signals:
     - traces
     - metrics

--- a/evals/ai-agent-scenarios.md
+++ b/evals/ai-agent-scenarios.md
@@ -108,13 +108,11 @@ Ensure proper resource attribution when multiple AI agents run in the same devel
 I'm instrumenting an AI coding agent that calls `bash` and `search_code`. Show me how the OpenTelemetry spans should be named.
 
 ### Expected Response (Key Points)
-- Uses the actual tool name as each execute-tool span name (for example `bash`, `search_code`)
-- Preserves `gen_ai.tool.name` on each tool span
-- Mentions the Semantic Conventions v1.41.0 span-naming requirement
-- Avoids recommending a generic `execute_tool` span name
+- Uses the stable `execute_tool` span name for each tool invocation
+- Preserves the actual tool name in `gen_ai.tool.name`
+- Avoids encoding unbounded or vendor-specific tool names into span names
 
 ### Failure Modes
-- Uses a generic `execute_tool` span name for every tool call
+- Encodes unbounded tool names into span names
 - Omits `gen_ai.tool.name`
-- Misses the v1.41.0 GenAI SemConv naming requirement
 - Gives generic tracing advice without tool-call specifics

--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -27,11 +27,11 @@ This file is automatically flagged for review when changes occur in:
 
 | Agent | Vendor | Native OTel | Traces | Metrics | Logs/Events | GenAI SemConv | Hooks Support | Config Method | Config File / Env Vars | Protocol | Official Docs |
 |-------|--------|-------------|--------|---------|-------------|---------------|---------------|---------------|------------------------|----------|---------------|
-| **Claude Code** | Anthropic | ⚠️ metrics/logs only | ❌ | ✅ | ✅ | ❌ (custom `claude_code.*`) | ✅ governance wrapper | Env vars or `~/.claude/settings.json` | `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_*` | OTLP gRPC/HTTP | [docs](https://code.claude.com/docs/en/monitoring-usage) |
+| **Claude Code** | Anthropic | ⚠️ metrics/logs + traces beta | ⚠️ beta | ✅ | ✅ | ❌ (custom `claude_code.*`) | ✅ governance wrapper | Env vars or managed settings | `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_*` | OTLP gRPC/HTTP | [docs](https://code.claude.com/docs/en/monitoring-usage) |
 | **Gemini CLI** | Google | ✅ full | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | ✅ governance wrapper | `.gemini/settings.json` or env vars | `GEMINI_TELEMETRY_*` | OTLP gRPC | [docs](https://geminicli.com/docs/cli/telemetry/) |
 | **GitHub Copilot VS Code** | Microsoft | ✅ full | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | ⚠️ launcher wrapper only | VS Code `settings.json` or env var | `COPILOT_OTEL_ENABLED` | OTLP HTTP | [docs](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents) |
 | **GitHub Copilot CLI** | Microsoft | ✅ full | ✅ | ✅ | ✅ | ✅ (`gen_ai.*`) | ✅ governance wrapper | Same span model as VS Code | `COPILOT_OTEL_ENABLED` | OTLP HTTP | [docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference) |
-| **OpenAI Codex CLI** | OpenAI | ⚠️ partial | ⚠️ interactive only | ⚠️ interactive only | ✅ | ❌ (custom event names) | ✅ gap-filler + governance | `~/.codex/config.toml` `[otel]` section | `~/.codex/config.toml` | OTLP gRPC | [docs](https://developers.openai.com/codex/config-advanced) |
+| **OpenAI Codex CLI** | OpenAI | ⚠️ partial | ⚠️ verify per release/mode | ✅ | ✅ | ❌ (custom event names) | ✅ gap-filler + governance | `~/.codex/config.toml` `[otel]` section | `~/.codex/config.toml` | OTLP gRPC | [docs](https://developers.openai.com/codex/config-advanced) |
 | **Qwen Code** | Alibaba | ⚠️ partial | ⚠️ partial | ⚠️ partial | ⚠️ partial | ⚠️ partial | ✅ interim bridge | `.qwen/settings.json`, env vars, CLI flags | `.qwen/settings.json`, `QWEN_TELEMETRY_*`, `OTEL_*` | OTLP gRPC/HTTP | [docs](https://qwenlm.github.io/qwen-code-docs/en/developers/development/telemetry/) |
 | **OpenCode** | Anomaly | ❌ none | ❌ | ❌ | ❌ | ❌ | ✅ primary | Community plugin only | n/a | n/a | [plugin](https://github.com/DEVtheOPS/opencode-plugin-otel) |
 | **Pi Agent** | open-source | ❌ none | ❌ | ❌ | ⚠️ install telemetry only | ❌ | ✅ primary | `~/.pi/agent/settings.json` or `.pi/settings.json` | `PI_TELEMETRY`, `enableInstallTelemetry` | n/a | [docs](https://pi.dev) |
@@ -55,7 +55,7 @@ This file is automatically flagged for review when changes occur in:
 
 ### 2.1 Claude Code
 
-Claude Code emits **metrics** and **logs/events** only — no traces. Telemetry is opt-in.
+Claude Code emits **metrics** and **logs/events**, with **traces available as a beta feature**. Telemetry is opt-in.
 
 **Minimum config (env vars):**
 
@@ -63,6 +63,7 @@ Claude Code emits **metrics** and **logs/events** only — no traces. Telemetry 
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
+export OTEL_TRACES_EXPORTER=otlp # beta
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 ```
@@ -75,6 +76,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "OTEL_METRICS_EXPORTER": "otlp",
     "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_TRACES_EXPORTER": "otlp",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative"
@@ -95,6 +97,8 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 > ✅ **Bounded metric dimension**: Prefer `OTEL_METRICS_INCLUDE_ENTRYPOINT=true` over `OTEL_METRICS_INCLUDE_SESSION_ID=true` when you need a stable breakdown of CLI vs IDE/SDK launches. `app.entrypoint` stays bounded and is safe for dashboards; `session.id` is still high-cardinality.
 
+> ⚠️ **Trace maturity**: Claude Code traces are beta. Validate signal shape, exporter behavior, and privacy controls before making them a production dependency.
+
 ---
 
 ### 2.2 Gemini CLI
@@ -107,9 +111,12 @@ Gemini CLI emits full **traces + metrics + logs** using GenAI semantic conventio
 {
   "telemetry": {
     "enabled": true,
+    "traces": true,
+    "target": "local",
     "otlpEndpoint": "http://localhost:4317",
     "otlpProtocol": "grpc",
-    "logPrompts": false
+    "logPrompts": false,
+    "useCollector": true
   }
 }
 ```
@@ -119,9 +126,11 @@ Gemini CLI emits full **traces + metrics + logs** using GenAI semantic conventio
 ```bash
 export GEMINI_TELEMETRY_ENABLED=true
 export GEMINI_TELEMETRY_OTLP_ENDPOINT=http://localhost:4317
+export GEMINI_TELEMETRY_TRACES_ENABLED=true
+export GEMINI_TELEMETRY_LOG_PROMPTS=false
 ```
 
-> ✅ Gemini CLI v0.34.0+ follows `gen_ai.*` GenAI semantic conventions. Traces include full span hierarchy for multi-step agent operations.
+> ✅ Gemini CLI v0.34.0+ supports traces, metrics, and logs. Explicitly disable prompt logging (`logPrompts: false`) for shared or production environments, because the current official default is `true`.
 
 ---
 
@@ -147,6 +156,13 @@ export COPILOT_OTEL_OTLP_ENDPOINT=http://localhost:4318
 
 > ⚠️ `captureContent: true` captures **full prompts and responses**. Keep this `false` in shared or production environments. See [Privacy section](#6-privacy--cardinality-considerations).
 
+Copilot now emits three attribute namespaces: `gen_ai.*` for standard fields,
+`github.copilot.*` as the preferred Copilot-specific namespace, and legacy
+`copilot_chat.*` fields for compatibility. New dashboards and transforms should
+prefer `github.copilot.*` while retaining legacy aliases when existing
+consumers depend on them. Tool spans use the stable span name `execute_tool`;
+the actual tool name belongs in `gen_ai.tool.name`.
+
 ---
 
 ### 2.4 GitHub Copilot CLI
@@ -164,7 +180,7 @@ export COPILOT_OTEL_OTLP_ENDPOINT=http://localhost:4318
 
 ### 2.5 OpenAI Codex CLI
 
-Codex CLI supports telemetry in **interactive mode only**. `codex exec` and `codex mcp-server` have known gaps (see [Known Gaps](#7-known-gaps--workarounds)).
+Codex CLI's documented telemetry is mode-sensitive. Verify the installed release before assuming parity between interactive, `exec`, and `mcp-server` modes.
 
 **Config file (`~/.codex/config.toml`):**
 
@@ -181,7 +197,7 @@ log_user_prompt = false
 exporter = { otlp-grpc = { endpoint = "http://localhost:4317" } }
 ```
 
-> ⚠️ Codex v0.105.0+ is required. `codex exec` drops metrics entirely. `codex mcp-server` has zero OTel support. See [open issue #12913](https://github.com/openai/codex/issues/12913). As of rust-v0.130.0, Codex CLI added configurable OpenTelemetry trace metadata fields.
+> ⚠️ Codex's documented OTel surface is structured log events and metrics for API requests, tool calls, and sessions; do not promise distributed traces without verifying the installed release. `codex exec` and `codex mcp-server` remain separate coverage paths and should be validated independently.
 
 ---
 
@@ -234,7 +250,7 @@ otel-hooks --service-name cursor --otlp-endpoint http://localhost:4317 -- cursor
 
 | Agent | Native OTel | Hooks Role | Recommended Usage |
 |-------|-------------|------------|-------------------|
-| **Claude Code** | ⚠️ metrics/logs only | Governance wrapper | Keep native metrics/logs enabled; add hooks when you need standardized start/stop audit events, resource attributes, or launch-time controls across agents. |
+| **Claude Code** | ⚠️ metrics/logs + traces beta | Governance wrapper | Prefer native metrics/logs; evaluate beta traces separately, and add hooks when you need standardized start/stop audit events, resource attributes, or launch-time controls across agents. |
 | **Gemini CLI** | ✅ full | Governance wrapper | Prefer native telemetry for traces and GenAI semantics; add hooks only for organization-wide process-boundary controls or uniform invocation audit events. |
 | **GitHub Copilot CLI** | ✅ full | Governance wrapper | Use native telemetry for primary observability; add hooks when you need consistent launch policies, ownership tags, or process-boundary audit signals across multiple CLI agents. |
 | **GitHub Copilot VS Code** | ✅ full | Limited launcher wrapper | Prefer native telemetry. Hooks can wrap the editor launch, but they provide only outer-process coverage because most agent activity occurs inside the desktop process after startup. |
@@ -400,9 +416,9 @@ Do not generate `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.tool.
 | Agent | Span Name | Kind | Key Attributes | Child Spans |
 |-------|-----------|------|----------------|-------------|
 | GenAI inference | `{gen_ai.operation.name} {gen_ai.request.model}` | `CLIENT` (usually) | `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model` | tool call spans |
-| GenAI tool execution | `execute_tool {gen_ai.tool.name}` | `INTERNAL` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.call.id` | none |
+| GenAI tool execution | `execute_tool` | `INTERNAL` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.call.id` | none |
 
-> **Note**: Claude Code emits **no traces**. Use `prompt.id` correlation across log events as a pseudo-trace (see [Known Gaps](#7-known-gaps--workarounds)).
+> **Note**: Claude Code traces are beta. If traces are disabled or unavailable, use native `prompt.id` correlation across log events as a fallback.
 
 ---
 
@@ -500,9 +516,9 @@ See `references/security.md` for comprehensive OTTL redaction patterns.
 
 ## 7. Known Gaps & Workarounds
 
-### 7.1 Claude Code: No Traces
+### 7.1 Claude Code: Beta Traces
 
-**Gap**: Claude Code emits metrics and logs/events, but **no distributed traces**. There is no W3C `traceparent` propagation.
+**Gap**: Claude Code's trace export is beta and should not be treated as a stable cross-agent tracing contract. There may still be deployments where only metrics and logs/events are enabled.
 
 **Workaround — Pseudo-trace via `prompt.id` correlation**:
 
@@ -520,11 +536,11 @@ Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123
 
 ### 7.2 Codex CLI: Exec and MCP-Server Gaps
 
-**Gap**: `codex exec` (non-interactive batch mode) drops **all metrics**. `codex mcp-server` has **zero OTel instrumentation**.
+**Gap**: Codex telemetry is mode-sensitive, and the documented OTel surface does
+not establish uniform distributed-trace coverage across interactive, `exec`, and
+`mcp-server` modes.
 
-**Status**: Open issue — [github.com/openai/codex/issues/12913](https://github.com/openai/codex/issues/12913)
-
-**Workaround**: Use interactive `codex` mode for telemetry. For `codex exec` pipelines, instrument the calling shell script with timing/exit code metrics via a Prometheus Pushgateway or write structured JSON logs that a filelog receiver can ingest.
+**Workaround**: Verify the installed Codex release and mode independently. For `codex exec` pipelines, instrument the calling shell script with timing/exit code metrics via a Prometheus Pushgateway or write structured JSON logs that a filelog receiver can ingest.
 
 ### 7.3 Qwen Code: Runtime Active, Partial GenAI Dual-Emit
 
@@ -548,14 +564,14 @@ Query in Loki/OpenSearch: `{job="claude_code"} | json | prompt_id="prompt_abc123
 
 ### 7.6 GenAI SemConv Coverage
 
-**Current execute-tool convention**: Set `gen_ai.operation.name` to `execute_tool`, populate `gen_ai.tool.name`, and name the span `execute_tool {gen_ai.tool.name}` (for example, `execute_tool bash`). A bare `execute_tool` span loses useful indexing context, while a span named only `bash` does not follow the current convention.
+**Current execute-tool convention**: Set `gen_ai.operation.name` to `execute_tool`, populate `gen_ai.tool.name`, and use the stable span name `execute_tool`. Keep the actual tool name in `gen_ai.tool.name`; do not encode unbounded or vendor-specific tool names into span names.
 
 | Agent | Uses `gen_ai.*` | Custom Prefix | Notes |
 |-------|----------------|---------------|-------|
 | Gemini CLI | ✅ Full | — | Verify emitted fields against the agent version and Development GenAI conventions |
 | GitHub Copilot | ✅ Full | — | Verify emitted fields against the agent version and Development GenAI conventions |
 | Claude Code | ❌ | `claude_code.*` | Preserve the vendor schema and identify the agent with `service.name` |
-| Codex CLI | ❌ | `codex.*` | Custom event names, partial coverage |
+| Codex CLI | ❌ | `codex.*` | Custom event names, metrics/log events, and partial mode coverage |
 | Qwen Code | ⚠️ partial | `qwen-code.*` | v0.16.1 dual-emits selected `gen_ai.*` attributes (`gen_ai.request.model`, `gen_ai.usage.*`, `gen_ai.server.time_to_first_token`); private names remain authoritative |
 
 For unified dashboards, group coding agents by `service.name` and providers by `gen_ai.provider.name`. Do not translate an agent product name into `gen_ai.provider.name`, and do not recreate deprecated `gen_ai.system` attributes.

--- a/references/ai-agents.md
+++ b/references/ai-agents.md
@@ -94,9 +94,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 | `OTEL_METRICS_INCLUDE_ENTRYPOINT` | `false` | Adds bounded `app.entrypoint` as a metric dimension for dashboard slicing |
 
 > ⚠️ **Temporality**: Claude Code emits cumulative metrics. Set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative` to match. VictoriaMetrics and some Prometheus backends will silently drop delta-converted metrics from cumulative sources.
-
 > ✅ **Bounded metric dimension**: Prefer `OTEL_METRICS_INCLUDE_ENTRYPOINT=true` over `OTEL_METRICS_INCLUDE_SESSION_ID=true` when you need a stable breakdown of CLI vs IDE/SDK launches. `app.entrypoint` stays bounded and is safe for dashboards; `session.id` is still high-cardinality.
-
 > ⚠️ **Trace maturity**: Claude Code traces are beta. Validate signal shape, exporter behavior, and privacy controls before making them a production dependency.
 
 ---

--- a/references/compatibility.md
+++ b/references/compatibility.md
@@ -13,10 +13,10 @@ Use this document for version-sensitive guidance that changes more frequently th
 
 ## AI agent telemetry compatibility
 
-- **Claude Code**: current release emits metrics plus logs/events, not traces; `OTEL_METRICS_INCLUDE_ENTRYPOINT=true` adds optional bounded `app.entrypoint`
+- **Claude Code**: current release emits metrics plus logs/events and beta traces; `OTEL_METRICS_INCLUDE_ENTRYPOINT=true` adds optional bounded `app.entrypoint`
 - **Gemini CLI**: v0.34.0+ emits traces, metrics, and logs with GenAI semantic conventions
 - **GitHub Copilot**: latest stable / Insiders builds expose traces, metrics, and events with GenAI semantic conventions
-- **Codex CLI**: v0.105.0+ emits traces and logs in interactive mode, with gaps in `exec` / `mcp-server`
+- **Codex CLI**: current documentation describes structured log events and metrics for API requests, tool calls, and sessions; verify trace support and mode-specific behavior in the installed release
 - **Qwen Code**: v0.16.1+ emits traces, metrics, and logs with partial `gen_ai.*` dual-emit layered on top of authoritative `qwen-code.*` fields
 
 ## Maintenance guidance

--- a/references/compatibility.md
+++ b/references/compatibility.md
@@ -16,7 +16,7 @@ Use this document for version-sensitive guidance that changes more frequently th
 - **Claude Code**: current release emits metrics plus logs/events and beta traces; `OTEL_METRICS_INCLUDE_ENTRYPOINT=true` adds optional bounded `app.entrypoint`
 - **Gemini CLI**: v0.34.0+ emits traces, metrics, and logs with GenAI semantic conventions
 - **GitHub Copilot**: latest stable / Insiders builds expose traces, metrics, and events with GenAI semantic conventions
-- **Codex CLI**: current documentation describes structured log events and metrics for API requests, tool calls, and sessions; verify trace support and mode-specific behavior in the installed release
+- **Codex CLI**: current documentation describes structured log events and metrics for API requests, tool calls, `exec`, and sessions; verify trace support and mode-specific behavior in the installed release
 - **Qwen Code**: v0.16.1+ emits traces, metrics, and logs with partial `gen_ai.*` dual-emit layered on top of authoritative `qwen-code.*` fields
 
 ## Maintenance guidance

--- a/references/instrumentation.md
+++ b/references/instrumentation.md
@@ -40,6 +40,28 @@ Instrumentation is the process of adding observability to application code. This
 - `fraud_detection` spans with risk scores
 - `inventory_check` spans with SKU and quantity
 
+### Go compile-time instrumentation
+
+For Go services that can be rebuilt, the stable Go Compile-Time Instrumentation
+v1 project provides a third option between manual SDK work and out-of-process
+eBPF instrumentation:
+
+- Run `otelc go build` instead of `go build`; the tool injects instrumentation
+  through the Go toolchain's `-toolexec` mechanism.
+- It can cover supported standard-library and dependency packages without source
+  changes, including `net/http`, `database/sql`, gRPC, Redis, and Go runtime
+  metrics.
+- Prefer compile-time instrumentation when the fleet can rebuild binaries and
+  needs repeatable CI/CD rollout. Prefer eBPF when binaries cannot be rebuilt,
+  and manual instrumentation when domain-specific spans or unsupported
+  libraries are required.
+- Confirm the supported-library list and emitted semantic conventions for the
+  installed release; coverage is intentionally narrower than the whole Go
+  ecosystem and expands over time.
+
+See the [Go compile-time instrumentation v1 announcement](https://opentelemetry.io/blog/2026/go-compile-time-instrumentation-v1/)
+and the [supported libraries](https://opentelemetry.io/docs/zero-code/go/compile-time/supported-libraries/).
+
 ### Auto-Instrumentation Setup
 
 #### Java (OpenTelemetry Java Agent)
@@ -211,7 +233,7 @@ public class PaymentService {
 | **Messaging** | `messaging.system`, `messaging.destination`, `messaging.operation` | `messaging.system = "kafka"` |
 | **Network** | `network.protocol.name`, `network.protocol.version` | `network.protocol.name = "http"` |
 | **Cloud** | `cloud.provider`, `cloud.platform`, `cloud.region` | `cloud.provider = "aws"` |
-| **GenAI** | `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.request.model` | `gen_ai.system = "openai"` |
+| **GenAI** | `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model` | `gen_ai.provider.name = "openai"` |
 | **Events** | `event.name`, structured log body | `event.name = "user.login"` |
 
 ### HTTP Semantic Conventions
@@ -246,14 +268,14 @@ span.set_attribute(SpanAttributes.SERVER_ADDRESS, "db.example.com")
 span.set_attribute(SpanAttributes.SERVER_PORT, 5432)
 ```
 
-### GenAI Semantic Conventions (v1.27.0+)
+### GenAI Semantic Conventions
 
 The `gen_ai/` namespace covers Generative AI operations (LLM calls, embeddings, etc.):
 
 ```python
 # Instrumenting an LLM API call (e.g., OpenAI Chat Completions)
 with tracer.start_as_current_span("chat.completion") as span:
-    span.set_attribute("gen_ai.system", "openai")           # ai system identifier
+    span.set_attribute("gen_ai.provider.name", "openai")     # model/provider identity
     span.set_attribute("gen_ai.operation.name", "chat")     # "chat", "text_completion", "embeddings"
     span.set_attribute("gen_ai.request.model", "gpt-4o")    # requested model
     span.set_attribute("gen_ai.request.max_tokens", 1024)
@@ -271,7 +293,7 @@ with tracer.start_as_current_span("chat.completion") as span:
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `gen_ai.system` | string | AI provider (`openai`, `anthropic`, `vertex_ai`, `aws_bedrock`) |
+| `gen_ai.provider.name` | string | Model/provider identity (`openai`, `anthropic`, `gcp.gen_ai`, `aws.bedrock`) |
 | `gen_ai.operation.name` | string | Operation type (`chat`, `text_completion`, `embeddings`) |
 | `gen_ai.request.model` | string | Requested model name |
 | `gen_ai.response.model` | string | Actual model used (may differ from request) |
@@ -302,7 +324,7 @@ token_counter = meter.create_counter(
 token_counter.add(
     response.usage.total_tokens,
     {
-        "gen_ai.system": "openai",
+        "gen_ai.provider.name": "openai",
         "gen_ai.operation.name": "chat",
         "gen_ai.token.type": "total",  # Common values include total/input/output; cache/reasoning buckets may appear as semantic conventions evolve
     }
@@ -319,6 +341,7 @@ When an SDK is initialized from **declarative configuration**, there is not yet 
 - Keep critical resource attributes (`service.name`, `deployment.environment.name`, ownership tags) explicit in config instead of relying on implicit detector merge order.
 - Verify the effective `Resource` through emitted telemetry, collector debug output, or integration tests — not by assuming the SDK exposes a post-merge resource object.
 - If you need downstream routing or access control based on resource attributes, test the serialized OTLP output end to end before promoting a declarative config change.
+- For OpenTelemetry Java agent 2.30+, prefer the current `ConfigProvider`/`DeclarativeConfigBridge` path for experimental declarative configuration; older `ConfigProperties` bridge APIs are compatibility layers and are being removed in a future major release.
 
 ### Events Semantic Conventions (v1.32.0+)
 

--- a/references/playbooks.md
+++ b/references/playbooks.md
@@ -94,6 +94,9 @@ document.
 | [Exposing OTel Collector in Kubernetes with Gateway API & mTLS](https://opentelemetry.io/blog/2025/expose-otel-collector-gateway-api/) | Gateway API, mTLS, external OTLP ingress, multi-cluster collector, hybrid cloud | Practical security and ingress pattern for centralized collector deployments | [security][security-ref], [architecture][architecture-ref], [collector][collector-ref] |
 | [How Mastodon Runs OpenTelemetry Collectors in Production](https://opentelemetry.io/blog/2026/devex-mastodon/) | small team, one collector per namespace, OpenTelemetry Operator, Argo CD, tail sampling, vendor-neutral observability | Strong operating model for keeping collector deployments simple, declarative, and reliable while preserving backend choice at production scale | [architecture][architecture-ref], [collector][collector-ref], [monitoring][monitoring-ref] |
 | [OpenTelemetry Profiles Enters Public Alpha](https://opentelemetry.io/blog/2026/profiles-alpha/) | profiles, profiling, OTLP Profiles, eBPF profiler, `pprof` receiver, profile correlation | Good routing target when users ask how continuous profiling fits into OpenTelemetry, especially around collector support and cross-signal correlation | [collector][collector-ref], [platforms][platforms-ref], [monitoring][monitoring-ref] |
+| [Announcing v1 of OpenTelemetry Go Compile-Time Instrumentation](https://opentelemetry.io/blog/2026/go-compile-time-instrumentation-v1/) | Go zero-code, `otelc`, `-toolexec`, build-time instrumentation, supported libraries | Gives Go teams a stable build-time option between manual SDK work and eBPF; compare rebuild requirements, library coverage, and runtime trade-offs | [instrumentation][instrumentation-ref], [platforms][platforms-ref] |
+| [Inside the LLM Call: GenAI Observability with OpenTelemetry](https://opentelemetry.io/blog/2026/genai-observability/) | GenAI traces, `invoke_agent`, `chat`, `execute_tool`, token usage, prompt capture, Copilot, Codex, Claude Code | Routes agent-observability questions to current signal shapes, content-capture controls, and the distinction between stable span names and tool-name attributes | [ai-agents][ai-agents-ref], [instrumentation][instrumentation-ref], [security][security-ref] |
+| [Introducing OTel Blueprints and Reference Implementations](https://opentelemetry.io/blog/2026/blueprints-intro/) | blueprints, reference implementations, prescriptive deployment, end-user adoption, holistic strategy | Encourages scoped deployment strategies that connect SDK, Collector, semantic conventions, and operations instead of isolated snippets | [architecture][architecture-ref], [collector][collector-ref], [instrumentation][instrumentation-ref] |
 | [Demystifying Automatic Instrumentation: How the Magic Actually Works](https://opentelemetry.io/blog/2025/demystifying-auto-instrumentation/) | auto-instrumentation, zero-code, bytecode instrumentation, eBPF, runtime hooks | Helps the skill explain *which* automatic instrumentation mechanism fits a runtime | [instrumentation][instrumentation-ref], [platforms][platforms-ref] |
 | [OpenTelemetry Logging and You](https://opentelemetry.io/blog/2025/opentelemetry-logging-and-you/) | logs, events, Logs API, log bridges, signal correlation | Useful when users ask how logs relate to traces and metrics in OTel's model | [instrumentation][instrumentation-ref], [collector][collector-ref] |
 | [How to Name Your Spans](https://opentelemetry.io/blog/2025/how-to-name-your-spans/) | span naming, low cardinality, semantic conventions, business spans | Good routing target for custom instrumentation and naming guidance | [instrumentation][instrumentation-ref] |
@@ -215,6 +218,9 @@ explanations.
 - **Gateway API + mTLS playbook source**: https://opentelemetry.io/blog/2025/expose-otel-collector-gateway-api/
 - **Mastodon production collectors source**: https://opentelemetry.io/blog/2026/devex-mastodon/
 - **Profiles alpha source**: https://opentelemetry.io/blog/2026/profiles-alpha/
+- **Go compile-time instrumentation v1 source**: https://opentelemetry.io/blog/2026/go-compile-time-instrumentation-v1/
+- **GenAI observability source**: https://opentelemetry.io/blog/2026/genai-observability/
+- **OTel blueprints source**: https://opentelemetry.io/blog/2026/blueprints-intro/
 - **Lambda extension playbook source**: https://opentelemetry.io/blog/2025/observing-lambdas/
 - **Auto-instrumentation strategy source**: https://opentelemetry.io/blog/2025/demystifying-auto-instrumentation/
 - **Logging source**: https://opentelemetry.io/blog/2025/opentelemetry-logging-and-you/
@@ -242,6 +248,7 @@ explanations.
 [platforms-ref]: platforms.md
 [sampling-ref]: sampling.md
 [security-ref]: security.md
+[ai-agents-ref]: ai-agents.md
 
 ---
 

--- a/tests/ai-agent-scenarios.md
+++ b/tests/ai-agent-scenarios.md
@@ -32,7 +32,7 @@
 
 - ✅ Includes `CLAUDE_CODE_ENABLE_TELEMETRY=1` as prerequisite
 - ✅ Provides exact env vars: `OTEL_METRICS_EXPORTER=otlp`, `OTEL_LOGS_EXPORTER=otlp`
-- ✅ Shows `~/.claude/settings.json` persistent config format
+- ✅ Shows managed-settings persistence, with `~/.claude/settings.json` as a concrete example
 - ✅ Sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`
 - ✅ Warns about `OTEL_METRICS_INCLUDE_SESSION_ID` and cardinality risk
 - ✅ Mentions privacy controls are off by default
@@ -41,7 +41,7 @@
 ### Compliance Check
 
 - [ ] Response includes `CLAUDE_CODE_ENABLE_TELEMETRY=1`
-- [ ] Response includes `settings.json` persistent config example
+- [ ] Response includes managed-settings persistence, optionally with a `settings.json` example
 - [ ] Response mentions cumulative temporality preference
 - [ ] Response warns about session.id as metric dimension
 - [ ] Response notes traces are beta
@@ -195,9 +195,9 @@
 
 ### Expected WITHOUT skill (RED baseline)
 
-- May use a generic `execute_tool` span name for every tool call
+- May use tool-specific span names or `execute_tool {tool}`
 - May omit `gen_ai.tool.name`
-- Likely misses the stable `execute_tool` span name and `gen_ai.tool.name` attribute
+- Likely misses the stable `execute_tool` span name or fails to preserve the tool name in `gen_ai.tool.name`
 
 ### Expected WITH skill (GREEN target)
 

--- a/tests/ai-agent-scenarios.md
+++ b/tests/ai-agent-scenarios.md
@@ -36,7 +36,7 @@
 - ✅ Sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`
 - ✅ Warns about `OTEL_METRICS_INCLUDE_SESSION_ID` and cardinality risk
 - ✅ Mentions privacy controls are off by default
-- ✅ Notes Claude Code emits metrics + logs, NOT traces
+- ✅ Notes Claude Code emits metrics + logs and that traces are beta
 
 ### Compliance Check
 
@@ -44,7 +44,7 @@
 - [ ] Response includes `settings.json` persistent config example
 - [ ] Response mentions cumulative temporality preference
 - [ ] Response warns about session.id as metric dimension
-- [ ] Response notes no traces are emitted
+- [ ] Response notes traces are beta
 
 ---
 
@@ -68,9 +68,9 @@
 - ✅ Prefers OTLP gRPC by default, but explains when OTLP HTTP is the right fallback
 - ✅ `memory_limiter` as first processor in every pipeline
 - ✅ `resource` processor to tag `telemetry.source.type: ai-coding-agent`
-- ✅ `transform` processor adding `gen_ai.system` attribute to Claude Code data
+- ✅ Preserves vendor-native Claude Code fields and does not synthesize deprecated `gen_ai.system`
 - ✅ Separate pipelines for metrics, logs, traces
-- ✅ Notes Claude Code emits no traces (traces pipeline still useful for Gemini CLI)
+- ✅ Notes Claude Code traces are beta (traces pipeline remains useful for Gemini CLI)
 - ✅ `batch` processor last before exporters
 
 ### Compliance Check
@@ -80,7 +80,7 @@
 - [ ] `memory_limiter` is first processor
 - [ ] `resource` processor normalizes agent identity
 - [ ] Separate metrics/logs/traces pipelines
-- [ ] Notes Claude Code has no traces
+- [ ] Notes Claude Code trace support is beta
 
 ---
 
@@ -102,8 +102,8 @@
 
 - ✅ Gemini CLI: full traces ✅, follows `gen_ai.*` SemConv, v0.34.0+
 - ✅ GitHub Copilot (VS Code + CLI): full traces ✅, follows `gen_ai.*` SemConv
-- ✅ Claude Code: NO traces ❌ — metrics + logs only; use `prompt.id` as pseudo-trace correlation
-- ✅ Codex CLI: traces ⚠️ in interactive mode only; `codex exec` drops metrics
+- ✅ Claude Code: beta traces plus metrics/logs; use `prompt.id` correlation when traces are unavailable
+- ✅ Codex CLI: documented OTel surface is metrics/log events; verify trace support and mode-specific behavior
 - ✅ Qwen Code: partial native OTel ⚠️ with partial `gen_ai.*` dual-emit as of v0.16.1
 - ✅ OpenCode, Cursor, Windsurf, Aider: no native OTel ❌
 - ✅ Recommends Gemini CLI or Copilot if traces are a hard requirement
@@ -111,8 +111,8 @@
 ### Compliance Check
 
 - [ ] Correctly identifies Gemini CLI and Copilot as trace-capable
-- [ ] Correctly states Claude Code has NO traces
-- [ ] Mentions Codex CLI partial support limitation
+- [ ] Correctly states Claude Code traces are beta
+- [ ] Mentions Codex CLI's documented metrics/log-event surface and mode-specific limitation
 - [ ] Notes Qwen Code has partial native OTel and partial `gen_ai.*` dual-emit in v0.16.1
 - [ ] Suggests GenAI SemConv coverage as selection criterion
 
@@ -197,21 +197,21 @@
 
 - May use a generic `execute_tool` span name for every tool call
 - May omit `gen_ai.tool.name`
-- Likely misses the Semantic Conventions v1.41.0 span-naming requirement
+- Likely misses the stable `execute_tool` span name and `gen_ai.tool.name` attribute
 
 ### Expected WITH skill (GREEN target)
 
-- ✅ Uses the actual tool name as the execute-tool span name (for example `bash`, `search_code`)
+- ✅ Uses the stable `execute_tool` span name
 - ✅ Preserves `gen_ai.tool.name` on each tool span
-- ✅ Mentions the v1.41.0 GenAI SemConv breaking change for tool-call span naming
-- ✅ Avoids collapsing all tool calls into a generic `execute_tool` span name
+- ✅ Keeps the actual tool name in `gen_ai.tool.name`
+- ✅ Avoids encoding unbounded or vendor-specific tool names into span names
 
 ### Compliance Check
 
-- [ ] Response names execute-tool spans with the actual tool name
+- [ ] Response uses the stable `execute_tool` span name
 - [ ] Response includes `gen_ai.tool.name`
-- [ ] Response mentions the v1.41.0 tool-call span-naming requirement
-- [ ] Response avoids a generic `execute_tool` span name
+- [ ] Response keeps the actual tool name in `gen_ai.tool.name`
+- [ ] Response avoids encoding unbounded tool names into span names
 
 ---
 
@@ -221,8 +221,8 @@ Document observed agent rationalizations and counter-guidance here as they are d
 
 | Rationalization | Counter |
 |----------------|---------|
-| "Claude Code supports traces via the OTEL_TRACES_EXPORTER env var" | Claude Code explicitly does NOT emit traces. `OTEL_TRACES_EXPORTER` is ignored. Only metrics and logs are emitted. |
+| "Claude Code traces are production-stable" | Claude Code trace export is beta; validate signal shape and keep a metrics/log fallback. |
 | "You can use session.id as a metric label to track per-user costs" | session.id is unbounded cardinality. Use log queries with distinct count instead. |
 | "Qwen Code telemetry is still planned but not shipped" | Qwen Code ships native OTel. As of v0.16.1 it also dual-emits selected `gen_ai.*` attributes, but the private `qwen-code.*` fields remain authoritative while the schema settles. |
-| "Codex CLI telemetry works the same in exec mode" | `codex exec` drops ALL metrics. Interactive mode only for full telemetry. |
-| "Use a generic `execute_tool` span name for all agent tool calls" | GenAI SemConv v1.41.0 requires execute-tool spans to use the actual tool name while still populating `gen_ai.tool.name`. |
+| "Codex CLI telemetry works the same in every mode" | The documented OTel surface and mode coverage must be verified independently for the installed release. |
+| "Put every tool name into the span name" | Use the stable `execute_tool` span name and put the actual tool name in `gen_ai.tool.name`. |

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "o11y-dev/opentelemetry-skill",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "summary": "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation across Kubernetes, ECS, serverless, and standalone deployments. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot).",
   "docs": "docs/index.md",


### PR DESCRIPTION
## Summary
- Refresh AI-agent telemetry guidance for Claude Code, Gemini CLI, Copilot, Codex, and GenAI semantic conventions.
- Add current OpenTelemetry playbooks for Go compile-time instrumentation v1, GenAI observability, and OTel blueprints.
- Add Go compile-time instrumentation to upstream monitoring and update compatibility, evaluations, tests, and changelog guidance.

## Validation
- `git diff --check`
- JSON/YAML parsing
- SKILL.md frontmatter validation
- Internal reference-link validation