### PR TITLE
ci: auto-bump Tessl patch releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,25 +11,15 @@ on:
       - '.cursor-plugin/**'
       - '.github/workflows/publish.yml'
   workflow_dispatch:
-    inputs:
-      bump:
-        description: Version bump level for a manual release
-        required: true
-        type: choice
-        options:
-          - auto
-          - patch
-          - minor
-          - major
-        default: auto
-
-permissions:
-  contents: read
 
 jobs:
   publish:
     name: Publish tile to Tessl registry
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     env:
       TESSL_API_TOKEN: ${{ secrets.TESSL_API_TOKEN }}
 
@@ -37,28 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Tessl CLI
+      - name: Publish with automatic patch versioning
         if: ${{ env.TESSL_API_TOKEN != '' }}
-        uses: tesslio/setup-tessl@v2
+        uses: tesslio/patch-version-publish@v1
         with:
           token: ${{ env.TESSL_API_TOKEN }}
-
-      - name: Lint tile
-        if: ${{ env.TESSL_API_TOKEN != '' }}
-        run: tessl tile lint
-
-      - name: Publish tile
-        if: ${{ env.TESSL_API_TOKEN != '' }}
-        env:
-          TESSL_BUMP: ${{ inputs.bump || 'auto' }}
-        run: |
-          if [ "$TESSL_BUMP" = "auto" ]; then
-            echo "Using the safe automatic patch bump."
-            tessl tile publish --bump patch
-          else
-            echo "Using the requested $TESSL_BUMP bump."
-            tessl tile publish --bump "$TESSL_BUMP"
-          fi
 
       - name: Skip publish when token is missing
         if: ${{ env.TESSL_API_TOKEN == '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,17 @@ on:
       - '.cursor-plugin/**'
       - '.github/workflows/publish.yml'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump level for a manual release
+        required: true
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
 
 permissions:
   contents: read
@@ -38,7 +49,16 @@ jobs:
 
       - name: Publish tile
         if: ${{ env.TESSL_API_TOKEN != '' }}
-        run: tessl tile publish --bump patch
+        env:
+          TESSL_BUMP: ${{ inputs.bump || 'auto' }}
+        run: |
+          if [ "$TESSL_BUMP" = "auto" ]; then
+            echo "Using the safe automatic patch bump."
+            tessl tile publish --bump patch
+          else
+            echo "Using the requested $TESSL_BUMP bump."
+            tessl tile publish --bump "$TESSL_BUMP"
+          fi
 
       - name: Skip publish when token is missing
         if: ${{ env.TESSL_API_TOKEN == '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, main]
     paths:
       - 'SKILL.md'
+      - 'tile.json'
       - 'references/**/*.md'
       - '.claude-plugin/**'
       - '.cursor-plugin/**'
@@ -37,7 +38,7 @@ jobs:
 
       - name: Publish tile
         if: ${{ env.TESSL_API_TOKEN != '' }}
-        run: tessl tile publish
+        run: tessl tile publish --bump patch
 
       - name: Skip publish when token is missing
         if: ${{ env.TESSL_API_TOKEN == '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update instrumentation guidance from deprecated `gen_ai.system` to `gen_ai.provider.name` and document stable Go compile-time instrumentation as an alternative to eBPF and manual SDK work
 - Migrate Collector examples and evaluations to canonical component IDs and raise the compatibility floor to v0.153.0
 - Document sparse exporter-helper failure metrics and expand upstream watcher coverage for GenAI conventions and exporter helpers
-- Bump aligned Tessl skill and tile metadata from `0.4.0` to `0.5.0`
+- Bump aligned Tessl skill and tile metadata from `0.4.0` to `0.5.1`
 
 ## [1.3.0] - 2026-05-08
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,8 +30,8 @@ tags:
   - ai-agent
 metadata:
   author: o11y.dev
-  version: 0.5.0
-  tessl_version: 0.5.0
+  version: 0.5.1
+  tessl_version: 0.5.1
   signals:
     - traces
     - metrics

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,125 +1,29 @@
 ---
 name: opentelemetry-skill
 description: "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot)."
-license: Apache-2.0
-tags:
-  - opentelemetry
-  - otel
-  - observability
-  - telemetry
-  - monitoring
-  - tracing
-  - metrics
-  - logs
-  - collector
-  - otelcol
-  - pipeline
-  - instrumentation
-  - kubernetes
-  - ecs
-  - docker
-  - serverless
-  - deployment
-  - architecture
-  - sampling
-  - cardinality
-  - security
-  - ottl
-  - transform
-  - codex
-  - ai-agent
 metadata:
   author: o11y.dev
   version: 0.5.1
   tessl_version: 0.5.1
-  signals:
-    - traces
-    - metrics
-    - logs
-    - profiles
-  deployments:
-    - kubernetes
-    - ecs
-    - docker
-    - vm
-    - serverless
-    - lambda
-    - gcp-functions
-    - azure-functions
-  deployment_patterns:
-    - daemonset
-    - sidecar
-    - gateway
-    - standalone
-    - serverless
-  supported_platforms:
-    - aws
-    - gcp
-    - azure
-    - on-premises
-  vendor_agnostic: true
-  triggers:
-    file_patterns:
-      - "**/collector*.yaml"
-      - "**/otelcol*.yaml"
-      - "**/values*.yaml"
-      - "**/trace-config*.yaml"
-      - "**/metric-config*.yaml"
-      - "**/log-config*.yaml"
-      - "**/helm*.yaml"
-      - "**/docker-compose*.yaml"
-      - "**/task-definition*.yaml"
-      - "**/task-definition*.json"
-    config_keys:
-      - "receivers:"
-      - "processors:"
-      - "exporters:"
-      - "service:"
-      - "pipelines:"
-      - "extensions:"
-      - "connectors:"
-    keywords:
-      - opentelemetry
-      - otel
-      - otelcol
-      - collector
-      - observability
-      - traces
-      - metrics
-      - logs
-      - pipeline
-      - sampler
-      - sampling
-      - cardinality
-      - instrumentation
-      - kubernetes
-      - helm
-      - ecs
-      - docker
-      - compose
-      - serverless
-      - lambda
-      - deployment
-      - architecture
-      - receiver
-      - processor
-      - exporter
-      - connector
-      - span_metrics
-      - service_graph
-      - signal_to_metrics
-      - tail sampling
-      - memory limiter
-      - batch processor
-      - ottl
-      - transform
-      - security
-      - tls
-      - pii
-      - redaction
-      - codex
-      - ai-agent
-      - genai
+  license: Apache-2.0
+  tags: "opentelemetry, otel, observability, telemetry, monitoring, tracing, metrics, logs, collector, otelcol, pipeline, instrumentation, kubernetes, ecs, docker, serverless, deployment, architecture, sampling, cardinality, security, ottl, transform, codex, ai-agent"
+  signals: "traces, metrics, logs, profiles"
+  deployments: "kubernetes, ecs, docker, vm, serverless, lambda, gcp-functions, azure-functions"
+  deployment_patterns: "daemonset, sidecar, gateway, standalone, serverless"
+  supported_platforms: "aws, gcp, azure, on-premises"
+  vendor_agnostic: "true"
+  triggers: >-
+    file_patterns: **/collector*.yaml, **/otelcol*.yaml, **/values*.yaml,
+    **/trace-config*.yaml, **/metric-config*.yaml, **/log-config*.yaml,
+    **/helm*.yaml, **/docker-compose*.yaml, **/task-definition*.yaml,
+    **/task-definition*.json; config_keys: receivers:, processors:, exporters:,
+    service:, pipelines:, extensions:, connectors:; keywords: opentelemetry, otel,
+    otelcol, collector, observability, traces, metrics, logs, pipeline, sampler,
+    sampling, cardinality, instrumentation, kubernetes, helm, ecs, docker, compose,
+    serverless, lambda, deployment, architecture, receiver, processor, exporter,
+    connector, span_metrics, service_graph, signal_to_metrics, tail sampling,
+    memory limiter, batch processor, ottl, transform, security, tls, pii, redaction,
+    codex, ai-agent, genai
 ---
 
 # OpenTelemetry Skill

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "o11y-dev/opentelemetry-skill",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "summary": "Expert OpenTelemetry guidance for collector configuration, pipeline design, and production telemetry instrumentation across Kubernetes, ECS, serverless, and standalone deployments. Use when configuring collectors, designing pipelines, instrumenting applications, implementing sampling, managing cardinality, securing telemetry, writing OTTL transformations, or setting up AI coding agent observability (Claude Code, Codex, Gemini CLI, GitHub Copilot).",
   "docs": "docs/index.md",


### PR DESCRIPTION
## Summary
- bump the published skill metadata to 0.5.1 because 0.5.0 already exists
- use Tessl's official patch-version-publish action for routine automatic patch releases
- let intentional minor and major releases happen through explicit manifest version bumps
- grant the action the permissions needed to commit or open a version-bump PR
- trigger publishing when tile.json changes

This follows the Tessl lifecycle: routine changes auto-bump patches; planned minor or major releases are authored in the manifest.